### PR TITLE
Add Logitech MX Dialpad input support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,38 @@ scroll wheel, or programmable dial pad.
 
 | Action | Inputs |
 | --- | --- |
-| Previous item | Arrow Up, Page Up, wheel up |
-| Next item | Arrow Down, Page Down, wheel down |
-| Select/forward | Arrow Right, Enter, Space, primary mouse button |
-| Back | Arrow Left, Escape, Backspace, secondary/browser-back mouse button |
+| Previous item | Arrow Up, Page Up, media previous, wheel up |
+| Next item | Arrow Down, Page Down, media next, wheel down |
+| Select/forward | Arrow Right, Enter, Space, media play/pause, primary/middle/browser-forward button |
+| Back | Arrow Left, Escape, Backspace, browser-back/secondary button |
 | Main menu | Hold the back input |
+
+### Logitech MX Creative Dialpad
+
+The Dialpad is handled as a standard Bluetooth HID device; Reflectrum does not
+depend on Logi Options+. Roller or dial wheel events navigate, forward/select
+buttons open the highlighted item, and back buttons return to the previous
+screen. Bursty wheel events are throttled to one action every 90 ms by default.
+
+Open `http://127.0.0.1:3000/?input-debug=1` on the mirror to see each raw
+keyboard, wheel, or mouse event and the Reflectrum action it produces. Controls
+that appear as unusual function keys can be mapped without rebuilding:
+
+```js
+window.REFLECTRUM_CONFIG = {
+  input: {
+    keyMap: {
+      F13: 'UP_CLICK',
+      F14: 'DOWN_CLICK',
+      F15: 'PRIMARY_CLICK',
+      F16: 'SECONDARY_CLICK',
+    },
+  },
+};
+```
+
+See [deploy/README.md](deploy/README.md#logitech-mx-creative-dialpad) for
+Bluetooth pairing and Linux-level diagnostics.
 
 ## Runtime configuration
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ scroll wheel, or programmable dial pad.
 ### Logitech MX Creative Dialpad
 
 The Dialpad is handled as a standard Bluetooth HID device; Reflectrum does not
-depend on Logi Options+. Roller or dial wheel events navigate, forward/select
-buttons open the highlighted item, and back buttons return to the previous
-screen. Bursty wheel events are throttled to one action every 90 ms by default.
+depend on Logi Options+. Vertical roller and horizontal dial events navigate,
+forward/select buttons open the highlighted item, and back buttons return to
+the previous screen. Bursty wheel events are throttled to one action every 90
+ms by default.
 
 Open `http://127.0.0.1:3000/?input-debug=1` on the mirror to see each raw
 keyboard, wheel, or mouse event and the Reflectrum action it produces. Controls

--- a/deploy/42-reflectrum-logitech-permissions.rules
+++ b/deploy/42-reflectrum-logitech-permissions.rules
@@ -1,0 +1,17 @@
+# Vendored from Solaar 1.1.19 rules.d-uinput/42-logitech-unify-permissions.rules.
+# Allows the logged-in desktop user to read Logitech HID++ and emit uinput keys.
+KERNEL=="uinput", SUBSYSTEM=="misc", TAG+="uaccess", OPTIONS+="static_node=uinput"
+
+ACTION == "remove", GOTO="solaar_end"
+SUBSYSTEM != "hidraw", GOTO="solaar_end"
+
+ATTRS{idVendor}=="046d", GOTO="solaar_apply"
+ATTRS{idVendor}=="17ef", ATTRS{idProduct}=="6042", GOTO="solaar_apply"
+KERNELS == "0005:046D:*", GOTO="solaar_apply"
+
+GOTO="solaar_end"
+
+LABEL="solaar_apply"
+TAG+="uaccess"
+
+LABEL="solaar_end"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -67,6 +67,21 @@ the static application.
 
 ## Logitech MX Creative Dialpad
 
+Install Solaar 1.1.19 or newer before running the Reflectrum installer. Solaar
+translates the Dialpad's four HID++ buttons into ordinary keys that Chromium
+can receive; the wheels continue to use standard vertical and horizontal HID
+scroll events.
+
+```sh
+sudo apt install solaar
+solaar --version
+```
+
+Confirm that `solaar show` detects `MX Creative Dialpad` and lists Back Button,
+Forward Button, Button 6, and Left Scroll As Button 7. If the distribution
+package is older than 1.1.19 or does not detect the Dialpad, install the pinned
+version using Solaar's documented PyPI or pipx method before continuing.
+
 Pair the Dialpad directly with BlueZ. Put it in pairing mode, then run:
 
 ```sh
@@ -94,6 +109,20 @@ Then load `http://127.0.0.1:3000/?input-debug=1` in Chromium and exercise every
 button, roller direction, dial direction, and dial press. The overlay shows the
 raw browser event and mapped Reflectrum command.
 
+At graphical login, `reflectrum-mx-dialpad` starts Solaar, marks all four
+buttons as diverted, and applies these rules:
+
+| Dialpad control | Reflectrum action |
+| --- | --- |
+| Back Button | Back |
+| Forward Button | Select/forward |
+| Button 6 | Previous item |
+| Left Scroll As Button 7 | Next item |
+
+The installer also adds Solaar's version-pinned `uinput` udev rule so these
+synthetic key events work under the Pi's Wayland session. Reboot after the
+first installation so the graphical session receives the new device ACLs.
+
 If a control does not reach Chromium, inspect the Linux input layer:
 
 ```sh
@@ -101,6 +130,5 @@ sudo libinput debug-events
 sudo evtest
 ```
 
-Record the event codes before adding a userspace input daemon. The current
-adapter deliberately uses standard HID events and deployment-local key maps;
-it does not require a vendor driver or an unattended browser permission.
+Solaar handles the vendor HID++ buttons outside the browser, avoiding WebHID's
+interactive permission prompt. Reflectrum itself remains device-independent.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -64,3 +64,43 @@ sudo systemctl restart reflectrum-web
 
 Chromium requests `/api/calendar`, so the private feed URL is never stored in
 the static application.
+
+## Logitech MX Creative Dialpad
+
+Pair the Dialpad directly with BlueZ. Put it in pairing mode, then run:
+
+```sh
+bluetoothctl
+power on
+agent on
+default-agent
+scan on
+devices
+pair DEVICE_MAC
+trust DEVICE_MAC
+connect DEVICE_MAC
+quit
+```
+
+Replace `DEVICE_MAC` with the address shown by `devices`. Confirm that it is
+available after pairing and after a reboot:
+
+```sh
+bluetoothctl devices Paired
+bluetoothctl info DEVICE_MAC
+```
+
+Then load `http://127.0.0.1:3000/?input-debug=1` in Chromium and exercise every
+button, roller direction, dial direction, and dial press. The overlay shows the
+raw browser event and mapped Reflectrum command.
+
+If a control does not reach Chromium, inspect the Linux input layer:
+
+```sh
+sudo libinput debug-events
+sudo evtest
+```
+
+Record the event codes before adding a userspace input daemon. The current
+adapter deliberately uses standard HID events and deployment-local key maps;
+it does not require a vendor driver or an unattended browser permission.

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -15,7 +15,7 @@ if [[ ! -f $source_dir/index.html ]]; then
   exit 1
 fi
 
-for command in chromium curl python3 wlr-randr; do
+for command in chromium curl python3 solaar wlr-randr; do
   command -v "$command" >/dev/null 2>&1 || {
     echo "Required command is missing: $command" >&2
     exit 1
@@ -40,6 +40,22 @@ install -o root -g root -m 0755 \
 install -o root -g root -m 0644 \
   "$repo_root/deploy/reflectrum-kiosk.desktop" \
   /etc/xdg/autostart/reflectrum-kiosk.desktop
+install -o root -g root -m 0755 \
+  "$repo_root/deploy/reflectrum-mx-dialpad" \
+  /usr/local/bin/reflectrum-mx-dialpad
+install -o root -g root -m 0644 \
+  "$repo_root/deploy/reflectrum-mx-dialpad.desktop" \
+  /etc/xdg/autostart/reflectrum-mx-dialpad.desktop
+
+install -d -o pi -g pi -m 0755 /home/pi/.config/solaar
+install -o pi -g pi -m 0644 \
+  "$repo_root/deploy/reflectrum-solaar-rules.yaml" \
+  /home/pi/.config/solaar/rules.yaml
+install -o root -g root -m 0644 \
+  "$repo_root/deploy/42-reflectrum-logitech-permissions.rules" \
+  /etc/udev/rules.d/42-reflectrum-logitech-permissions.rules
+udevadm control --reload-rules
+modprobe uinput
 
 systemctl daemon-reload
 systemctl enable --now reflectrum-web.service

--- a/deploy/reflectrum-mx-dialpad
+++ b/deploy/reflectrum-mx-dialpad
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+device_name='MX Creative Dialpad'
+controls=(
+  'Back Button'
+  'Forward Button'
+  'Button 6'
+  'Left Scroll As Button 7'
+)
+
+solaar_pid=''
+if ! pgrep -u "$(id -u)" -f '(^|/)solaar([[:space:]]|$)' >/dev/null 2>&1; then
+  solaar --window=hide --restart-on-wake-up &
+  solaar_pid=$!
+fi
+
+configured=0
+for _attempt in $(seq 1 30); do
+  configured=1
+  for control in "${controls[@]}"; do
+    if ! solaar config "$device_name" divert-keys "$control" Diverted >/dev/null 2>&1; then
+      configured=0
+      break
+    fi
+  done
+  ((configured)) && break
+  sleep 2
+done
+
+if (( ! configured )); then
+  echo "MX Dialpad was not available for Solaar configuration." >&2
+fi
+
+if [[ -n $solaar_pid ]]; then
+  wait "$solaar_pid"
+fi

--- a/deploy/reflectrum-mx-dialpad.desktop
+++ b/deploy/reflectrum-mx-dialpad.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=Reflectrum MX Dialpad
+Comment=Map MX Creative Dialpad buttons to Reflectrum navigation
+Exec=/usr/local/bin/reflectrum-mx-dialpad
+Terminal=false
+NoDisplay=true
+X-GNOME-Autostart-enabled=true

--- a/deploy/reflectrum-solaar-rules.yaml
+++ b/deploy/reflectrum-solaar-rules.yaml
@@ -1,0 +1,17 @@
+%YAML 1.3
+---
+- Key: [Back Button, pressed]
+- KeyPress: Escape
+...
+---
+- Key: [Forward Button, pressed]
+- KeyPress: Return
+...
+---
+- Key: [Button 6, pressed]
+- KeyPress: Up
+...
+---
+- Key: [Left Scroll As Button 7, pressed]
+- KeyPress: Down
+...

--- a/public/reflectrum-config.js
+++ b/public/reflectrum-config.js
@@ -3,4 +3,11 @@
 window.REFLECTRUM_CONFIG = {
   username: 'Michelle',
   // location: { lat: 0, long: 0, name: 'City, State' },
+  // inputDiagnostics: true,
+  // input: {
+  //   keyMap: { F13: 'UP_CLICK', F14: 'DOWN_CLICK' },
+  //   invertWheel: false,
+  //   wheelThreshold: 1,
+  //   wheelCooldownMs: 90,
+  // },
 };

--- a/src/components/InputDiagnostics.css
+++ b/src/components/InputDiagnostics.css
@@ -1,0 +1,36 @@
+.input-diagnostics {
+  position: fixed;
+  z-index: 9999;
+  right: 18px;
+  bottom: 18px;
+  left: 18px;
+  display: flex;
+  box-sizing: border-box;
+  max-height: 42vh;
+  padding: 18px;
+  overflow: hidden;
+  flex-direction: column;
+  gap: 7px;
+  border: 2px solid #00f5ea;
+  background: rgb(0 0 0 / 92%);
+  color: white;
+  font-size: 17px;
+  pointer-events: none;
+}
+
+.input-diagnostics strong {
+  color: #00f5ea;
+  font-size: 24px;
+}
+
+.input-diagnostics span {
+  color: #bdc3c7;
+}
+
+.input-diagnostics code {
+  overflow: hidden;
+  color: white;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/components/InputDiagnostics.jsx
+++ b/src/components/InputDiagnostics.jsx
@@ -6,7 +6,7 @@ const formatEvent = (event) => {
   const raw = event.source === 'keyboard'
     ? `${event.key || 'Unidentified'} (${event.code || 'no code'})`
     : event.source === 'wheel'
-      ? `deltaY ${Math.round(event.deltaY)}`
+      ? `deltaX ${Math.round(event.deltaX ?? 0)} / deltaY ${Math.round(event.deltaY ?? 0)}`
       : `button ${event.button}`;
   const result = event.action || 'unmapped';
   return `${event.source}/${event.type}: ${raw} → ${result}${event.throttled ? ' (throttled)' : ''}`;
@@ -20,7 +20,7 @@ export default function InputDiagnostics() {
   useEffect(() => {
     if (!enabled) return undefined;
     const listener = MirrorEvents.addListener('INPUT_DIAGNOSTIC', (event) => {
-      setEvents((current) => [event, ...current].slice(0, 8));
+      setEvents((current) => [event, ...current].slice(0, 32));
     });
     return () => listener.remove();
   }, [enabled]);

--- a/src/components/InputDiagnostics.jsx
+++ b/src/components/InputDiagnostics.jsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from 'react';
+import { MirrorEvents } from '../helpers/events';
+import './InputDiagnostics.css';
+
+const formatEvent = (event) => {
+  const raw = event.source === 'keyboard'
+    ? `${event.key || 'Unidentified'} (${event.code || 'no code'})`
+    : event.source === 'wheel'
+      ? `deltaY ${Math.round(event.deltaY)}`
+      : `button ${event.button}`;
+  const result = event.action || 'unmapped';
+  return `${event.source}/${event.type}: ${raw} → ${result}${event.throttled ? ' (throttled)' : ''}`;
+};
+
+export default function InputDiagnostics() {
+  const enabled = new URLSearchParams(window.location.search).get('input-debug') === '1'
+    || window.REFLECTRUM_CONFIG?.inputDiagnostics === true;
+  const [events, setEvents] = useState([]);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+    const listener = MirrorEvents.addListener('INPUT_DIAGNOSTIC', (event) => {
+      setEvents((current) => [event, ...current].slice(0, 8));
+    });
+    return () => listener.remove();
+  }, [enabled]);
+
+  if (!enabled) return null;
+  return (
+    <aside className="input-diagnostics" aria-live="polite">
+      <strong>Input diagnostics</strong>
+      <span>Move or press every Dialpad control.</span>
+      {events.length === 0
+        ? <code>No browser input received yet.</code>
+        : events.map((event, index) => <code key={`${event.timestamp}-${index}`}>{formatEvent(event)}</code>)}
+    </aside>
+  );
+}

--- a/src/helpers/events.jsx
+++ b/src/helpers/events.jsx
@@ -69,10 +69,10 @@ const registerInputListeners = () => {
   });
 
   document.addEventListener('wheel', (event) => {
-    const action = resolveWheelAction(event.deltaY, wheelConfig);
+    const action = resolveWheelAction(event, wheelConfig);
     const now = Date.now();
     const throttled = Boolean(action && now - lastWheelActionAt < wheelCooldownMs);
-    diagnostic({ source: 'wheel', type: 'wheel', deltaY: event.deltaY, action, throttled });
+    diagnostic({ source: 'wheel', type: 'wheel', deltaX: event.deltaX, deltaY: event.deltaY, action, throttled });
     if (!action) return;
 
     event.preventDefault();

--- a/src/helpers/events.jsx
+++ b/src/helpers/events.jsx
@@ -1,69 +1,98 @@
 import { EventEmitter } from 'fbemitter';
+import {
+  resolveKeyAction,
+  resolveMouseAction,
+  resolveWheelAction,
+} from './inputMapping.js';
 
 export const MirrorEvents = new EventEmitter();
 
-const pressState = {
-  primary: false,
-  secondary: false,
+const inputConfig = globalThis.REFLECTRUM_CONFIG?.input || {};
+const customKeyMap = inputConfig.keyMap || {};
+const wheelConfig = {
+  threshold: inputConfig.wheelThreshold ?? 1,
+  invert: inputConfig.invertWheel ?? false,
+};
+const wheelCooldownMs = inputConfig.wheelCooldownMs ?? 90;
+const pressState = { primary: false, secondary: false };
+let lastWheelActionAt = 0;
+
+const diagnostic = (details) => MirrorEvents.emit('INPUT_DIAGNOSTIC', {
+  timestamp: new Date().toISOString(),
+  ...details,
+});
+
+const pressName = (action) => {
+  if (action === 'PRIMARY_CLICK') return 'primary';
+  if (action === 'SECONDARY_CLICK') return 'secondary';
+  return null;
 };
 
-const upKeys = new Set(['ArrowUp', 'PageUp']);
-const downKeys = new Set(['ArrowDown', 'PageDown']);
-const primaryKeys = new Set(['ArrowRight', 'Enter', ' ']);
-const secondaryKeys = new Set(['ArrowLeft', 'Escape', 'Backspace']);
-
-const beginButtonPress = (name, eventName, event) => {
+const beginButtonPress = (name, event) => {
   event.preventDefault();
   if (pressState[name] === false) {
     pressState[name] = 'click';
   } else if (event.repeat && pressState[name] === 'click') {
     pressState[name] = 'hold';
-    MirrorEvents.emit(eventName);
+    MirrorEvents.emit(name === 'primary' ? 'PRIMARY_HOLD' : 'SECONDARY_HOLD');
   }
 };
 
-const finishButtonPress = (name, eventName, event) => {
+const finishButtonPress = (name, event) => {
   event.preventDefault();
   if (pressState[name] === 'click') {
-    MirrorEvents.emit(eventName);
+    MirrorEvents.emit(name === 'primary' ? 'PRIMARY_CLICK' : 'SECONDARY_CLICK');
   }
   pressState[name] = false;
 };
 
-document.addEventListener('keydown', (event) => {
-  if (upKeys.has(event.key)) {
+const registerInputListeners = () => {
+  document.addEventListener('keydown', (event) => {
+    const action = resolveKeyAction(event, customKeyMap);
+    diagnostic({ source: 'keyboard', type: 'keydown', key: event.key, code: event.code, repeat: event.repeat, action });
+    if (!action) return;
+
+    const name = pressName(action);
+    if (name) {
+      beginButtonPress(name, event);
+    } else {
+      event.preventDefault();
+      if (!event.repeat) MirrorEvents.emit(action);
+    }
+  });
+
+  document.addEventListener('keyup', (event) => {
+    const action = resolveKeyAction(event, customKeyMap);
+    diagnostic({ source: 'keyboard', type: 'keyup', key: event.key, code: event.code, repeat: false, action });
+    const name = pressName(action);
+    if (name) finishButtonPress(name, event);
+  });
+
+  document.addEventListener('wheel', (event) => {
+    const action = resolveWheelAction(event.deltaY, wheelConfig);
+    const now = Date.now();
+    const throttled = Boolean(action && now - lastWheelActionAt < wheelCooldownMs);
+    diagnostic({ source: 'wheel', type: 'wheel', deltaY: event.deltaY, action, throttled });
+    if (!action) return;
+
     event.preventDefault();
-    if (!event.repeat) MirrorEvents.emit('UP_CLICK');
-  } else if (downKeys.has(event.key)) {
-    event.preventDefault();
-    if (!event.repeat) MirrorEvents.emit('DOWN_CLICK');
-  } else if (primaryKeys.has(event.key)) {
-    beginButtonPress('primary', 'PRIMARY_HOLD', event);
-  } else if (secondaryKeys.has(event.key)) {
-    beginButtonPress('secondary', 'SECONDARY_HOLD', event);
-  }
-});
+    if (!throttled) {
+      lastWheelActionAt = now;
+      MirrorEvents.emit(action);
+    }
+  }, { passive: false });
 
-document.addEventListener('keyup', (event) => {
-  if (primaryKeys.has(event.key)) {
-    finishButtonPress('primary', 'PRIMARY_CLICK', event);
-  } else if (secondaryKeys.has(event.key)) {
-    finishButtonPress('secondary', 'SECONDARY_CLICK', event);
-  }
-});
+  document.addEventListener('mousedown', (event) => {
+    if (resolveMouseAction(event.button)) event.preventDefault();
+  });
 
-document.addEventListener('wheel', (event) => {
-  if (Math.abs(event.deltaY) < 1) return;
-  event.preventDefault();
-  MirrorEvents.emit(event.deltaY < 0 ? 'UP_CLICK' : 'DOWN_CLICK');
-}, { passive: false });
+  document.addEventListener('mouseup', (event) => {
+    const action = resolveMouseAction(event.button);
+    diagnostic({ source: 'mouse', type: 'mouseup', button: event.button, action });
+    if (action) MirrorEvents.emit(action);
+  });
 
-document.addEventListener('mouseup', (event) => {
-  if (event.button === 0 || event.button === 4) {
-    MirrorEvents.emit('PRIMARY_CLICK');
-  } else if (event.button === 2 || event.button === 3) {
-    MirrorEvents.emit('SECONDARY_CLICK');
-  }
-});
+  document.addEventListener('contextmenu', (event) => event.preventDefault());
+};
 
-document.addEventListener('contextmenu', (event) => event.preventDefault());
+if (typeof document !== 'undefined') registerInputListeners();

--- a/src/helpers/inputMapping.js
+++ b/src/helpers/inputMapping.js
@@ -1,0 +1,34 @@
+export const DEFAULT_KEY_MAP = Object.freeze({
+  ArrowUp: 'UP_CLICK',
+  PageUp: 'UP_CLICK',
+  MediaTrackPrevious: 'UP_CLICK',
+  ArrowDown: 'DOWN_CLICK',
+  PageDown: 'DOWN_CLICK',
+  MediaTrackNext: 'DOWN_CLICK',
+  ArrowRight: 'PRIMARY_CLICK',
+  Enter: 'PRIMARY_CLICK',
+  ' ': 'PRIMARY_CLICK',
+  BrowserForward: 'PRIMARY_CLICK',
+  MediaPlayPause: 'PRIMARY_CLICK',
+  ArrowLeft: 'SECONDARY_CLICK',
+  Escape: 'SECONDARY_CLICK',
+  Backspace: 'SECONDARY_CLICK',
+  BrowserBack: 'SECONDARY_CLICK',
+});
+
+export const resolveKeyAction = (event, customMap = {}) => {
+  const keyMap = { ...DEFAULT_KEY_MAP, ...customMap };
+  return keyMap[event.key] || keyMap[event.code] || null;
+};
+
+export const resolveMouseAction = (button) => {
+  if ([0, 1, 4].includes(button)) return 'PRIMARY_CLICK';
+  if ([2, 3].includes(button)) return 'SECONDARY_CLICK';
+  return null;
+};
+
+export const resolveWheelAction = (deltaY, { threshold = 1, invert = false } = {}) => {
+  if (Math.abs(deltaY) < threshold) return null;
+  const direction = invert ? -deltaY : deltaY;
+  return direction < 0 ? 'UP_CLICK' : 'DOWN_CLICK';
+};

--- a/src/helpers/inputMapping.js
+++ b/src/helpers/inputMapping.js
@@ -27,8 +27,9 @@ export const resolveMouseAction = (button) => {
   return null;
 };
 
-export const resolveWheelAction = (deltaY, { threshold = 1, invert = false } = {}) => {
-  if (Math.abs(deltaY) < threshold) return null;
-  const direction = invert ? -deltaY : deltaY;
+export const resolveWheelAction = ({ deltaX = 0, deltaY = 0 }, { threshold = 1, invert = false } = {}) => {
+  const dominantDelta = Math.abs(deltaY) >= Math.abs(deltaX) ? deltaY : deltaX;
+  if (Math.abs(dominantDelta) < threshold) return null;
+  const direction = invert ? -dominantDelta : dominantDelta;
   return direction < 0 ? 'UP_CLICK' : 'DOWN_CLICK';
 };

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
 import ViewStack from './components/ViewStack.jsx';
+import InputDiagnostics from './components/InputDiagnostics.jsx';
 import { mainMenu } from './components/MainMenu.jsx';
 import moment from 'moment';
 import './base.css';
@@ -169,6 +170,7 @@ const reflectrumApp = (state = data, action) => {
 createRoot(document.getElementById('target')).render(
   <Provider store={createStore(reflectrumApp)}>
     <ViewStack/>
+    <InputDiagnostics/>
   </Provider>
 );
 

--- a/test/input.test.js
+++ b/test/input.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  resolveKeyAction,
+  resolveMouseAction,
+  resolveWheelAction,
+} from '../src/helpers/inputMapping.js';
+
+test('maps standard navigation and Logitech-friendly media/browser keys', () => {
+  assert.equal(resolveKeyAction({ key: 'ArrowUp', code: 'ArrowUp' }), 'UP_CLICK');
+  assert.equal(resolveKeyAction({ key: 'MediaTrackNext', code: '' }), 'DOWN_CLICK');
+  assert.equal(resolveKeyAction({ key: 'BrowserForward', code: '' }), 'PRIMARY_CLICK');
+  assert.equal(resolveKeyAction({ key: 'BrowserBack', code: '' }), 'SECONDARY_CLICK');
+});
+
+test('allows deployment-local mappings by key or code', () => {
+  const custom = { F13: 'UP_CLICK', NumpadAdd: 'PRIMARY_CLICK' };
+  assert.equal(resolveKeyAction({ key: 'F13', code: 'F13' }, custom), 'UP_CLICK');
+  assert.equal(resolveKeyAction({ key: 'Unidentified', code: 'NumpadAdd' }, custom), 'PRIMARY_CLICK');
+  assert.equal(resolveKeyAction({ key: 'F20', code: 'F20' }, custom), null);
+});
+
+test('maps mouse and dial controls', () => {
+  assert.equal(resolveMouseAction(1), 'PRIMARY_CLICK');
+  assert.equal(resolveMouseAction(3), 'SECONDARY_CLICK');
+  assert.equal(resolveMouseAction(7), null);
+  assert.equal(resolveWheelAction(-100), 'UP_CLICK');
+  assert.equal(resolveWheelAction(100), 'DOWN_CLICK');
+  assert.equal(resolveWheelAction(0.5, { threshold: 1 }), null);
+  assert.equal(resolveWheelAction(100, { invert: true }), 'UP_CLICK');
+});

--- a/test/input.test.js
+++ b/test/input.test.js
@@ -24,8 +24,10 @@ test('maps mouse and dial controls', () => {
   assert.equal(resolveMouseAction(1), 'PRIMARY_CLICK');
   assert.equal(resolveMouseAction(3), 'SECONDARY_CLICK');
   assert.equal(resolveMouseAction(7), null);
-  assert.equal(resolveWheelAction(-100), 'UP_CLICK');
-  assert.equal(resolveWheelAction(100), 'DOWN_CLICK');
-  assert.equal(resolveWheelAction(0.5, { threshold: 1 }), null);
-  assert.equal(resolveWheelAction(100, { invert: true }), 'UP_CLICK');
+  assert.equal(resolveWheelAction({ deltaY: -100 }), 'UP_CLICK');
+  assert.equal(resolveWheelAction({ deltaY: 100 }), 'DOWN_CLICK');
+  assert.equal(resolveWheelAction({ deltaX: -100, deltaY: 0 }), 'UP_CLICK');
+  assert.equal(resolveWheelAction({ deltaX: 100, deltaY: 0 }), 'DOWN_CLICK');
+  assert.equal(resolveWheelAction({ deltaX: 0.5 }, { threshold: 1 }), null);
+  assert.equal(resolveWheelAction({ deltaX: 100 }, { invert: true }), 'UP_CLICK');
 });


### PR DESCRIPTION
## Summary
- add mappings for wheel/dial, middle/forward/back buttons, navigation keys, and media keys
- allow deployment-local raw key mappings for controls that appear as unusual HID codes
- throttle bursty wheel events for predictable one-step menu navigation
- add an on-screen raw-event diagnostic overlay at ?input-debug=1
- document BlueZ pairing and libinput/evtest diagnostics on Raspberry Pi
- add unit coverage for standard and custom input mappings

## Verification
- npm run check
- 8 provider/input tests pass
- Vite production build succeeds
- browser diagnostic captured ArrowDown as DOWN_CLICK with no console errors
- Pi inspection confirms the physical Dialpad is not paired yet, so final device event codes remain to be captured

## Stack
Depends on #19, which depends on #18 and #17.