### PR TITLE
Align menu active strip with selected row

### DIFF
--- a/src/components/menu/Menu.css
+++ b/src/components/menu/Menu.css
@@ -28,13 +28,17 @@ body > div {
   font-size: 45px;
 }
 
+.menu-list {
+  position: relative;
+}
+
 .menu-list-select-item {
   background-color: white;
   opacity: 0.4;
   position: absolute;
   height: 200px;
   width: 100%;
-  top: 280px;
+  top: 0;
   transition: top 0.5s ease;
 }
 

--- a/src/components/menu/MenuList.jsx
+++ b/src/components/menu/MenuList.jsx
@@ -8,7 +8,7 @@ class MenuList extends Component {
   render() {
     const props = this.props;
     return (
-        <div>
+        <div className="menu-list">
           <MenuListSelectedItem selectedItem={props.selectedItem} className="menu-list-select-item" />
           <div className="animated fadeInLeft">
           {

--- a/src/components/menu/MenuListSelectedItem.jsx
+++ b/src/components/menu/MenuListSelectedItem.jsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 class MenuListSelectedItem extends Component {
   render() {
     const props = this.props;
-    const top = (props.selectedItem * 200) + 280 + 'px'
+    const top = props.selectedItem * 200 + 'px'
 
     return (
       <div style={{top: top}} className="animated slideInRight menu-list-select-item"></div>


### PR DESCRIPTION
## Summary
- position the active strip relative to the menu list instead of the viewport
- remove the legacy 280 px header offset invalidated by border-box sizing
- keep the strip aligned as selection moves between rows

## Verification
- npm run check
- 8 tests pass and the Vite production build succeeds
- browser geometry shows zero-pixel top and bottom deltas for the first and second selected rows
- no browser console errors

## Stack
Depends on #20, which is the current top of the Reflectrum revival stack.