### PR TITLE
Add macOS MX Dialpad compatibility helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ window.REFLECTRUM_CONFIG = {
 See [deploy/README.md](deploy/README.md#logitech-mx-creative-dialpad) for
 Bluetooth pairing and Linux-level diagnostics.
 
+On macOS, auxiliary mouse buttons are intercepted before Chromium delivers
+them to page JavaScript. The project includes a small native compatibility
+helper that converts Dialpad buttons 3–6 to Escape, Return, Arrow Up, and Arrow
+Down. Install it with `./macos/install.sh`; macOS will require Accessibility
+and Input Monitoring permission for the `Reflectrum Dialpad` background app.
+
 ## Runtime configuration
 
 `public/reflectrum-config.js` supplies deployment-time defaults. Do not commit

--- a/macos/Info.plist
+++ b/macos/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key>
+  <string>Reflectrum Dialpad</string>
+  <key>CFBundleExecutable</key>
+  <string>ReflectrumDialpad</string>
+  <key>CFBundleIdentifier</key>
+  <string>io.reflectrum.dialpad</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>Reflectrum Dialpad</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>13.0</string>
+  <key>LSUIElement</key>
+  <true/>
+  <key>NSInputMonitoringUsageDescription</key>
+  <string>Reflectrum uses the MX Dialpad buttons to navigate the local mirror interface.</string>
+</dict>
+</plist>

--- a/macos/ReflectrumDialpad.swift
+++ b/macos/ReflectrumDialpad.swift
@@ -1,0 +1,139 @@
+import ApplicationServices
+import CoreGraphics
+import Foundation
+
+private struct ButtonBinding {
+    let buttonNumber: Int64
+    let keyCode: CGKeyCode
+    let name: String
+}
+
+private let bindings = [
+    ButtonBinding(buttonNumber: 3, keyCode: 53, name: "Back / Escape"),
+    ButtonBinding(buttonNumber: 4, keyCode: 36, name: "Forward / Return"),
+    ButtonBinding(buttonNumber: 5, keyCode: 126, name: "Button 6 / Arrow Up"),
+    ButtonBinding(buttonNumber: 6, keyCode: 125, name: "Button 7 / Arrow Down"),
+]
+
+private let bindingsByButton = Dictionary(uniqueKeysWithValues: bindings.map { ($0.buttonNumber, $0) })
+private let repeatQueue = DispatchQueue(label: "io.reflectrum.dialpad.repeat")
+private let repeatLock = NSLock()
+private var repeatTimers: [Int64: DispatchSourceTimer] = [:]
+private var eventTap: CFMachPort?
+
+private func log(_ message: String) {
+    let timestamp = ISO8601DateFormatter().string(from: Date())
+    FileHandle.standardError.write(Data("\(timestamp) \(message)\n".utf8))
+}
+
+private func postKey(_ binding: ButtonBinding, keyDown: Bool, isRepeat: Bool = false) {
+    guard let event = CGEvent(
+        keyboardEventSource: CGEventSource(stateID: .hidSystemState),
+        virtualKey: binding.keyCode,
+        keyDown: keyDown
+    ) else { return }
+    if isRepeat {
+        event.setIntegerValueField(.keyboardEventAutorepeat, value: 1)
+    }
+    event.post(tap: .cghidEventTap)
+}
+
+private func beginRepeat(for binding: ButtonBinding) {
+    repeatLock.lock()
+    defer { repeatLock.unlock() }
+    guard repeatTimers[binding.buttonNumber] == nil else { return }
+
+    let timer = DispatchSource.makeTimerSource(queue: repeatQueue)
+    timer.schedule(deadline: .now() + .milliseconds(500), repeating: .milliseconds(80))
+    timer.setEventHandler {
+        postKey(binding, keyDown: true, isRepeat: true)
+    }
+    repeatTimers[binding.buttonNumber] = timer
+    timer.resume()
+}
+
+private func endRepeat(for binding: ButtonBinding) {
+    repeatLock.lock()
+    let timer = repeatTimers.removeValue(forKey: binding.buttonNumber)
+    repeatLock.unlock()
+    timer?.cancel()
+}
+
+private func handleEvent(
+    proxy: CGEventTapProxy,
+    type: CGEventType,
+    event: CGEvent,
+    userInfo: UnsafeMutableRawPointer?
+) -> Unmanaged<CGEvent>? {
+    if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+        if let eventTap {
+            CGEvent.tapEnable(tap: eventTap, enable: true)
+        }
+        return Unmanaged.passUnretained(event)
+    }
+
+    let buttonNumber = event.getIntegerValueField(.mouseEventButtonNumber)
+    guard let binding = bindingsByButton[buttonNumber] else {
+        return Unmanaged.passUnretained(event)
+    }
+
+    switch type {
+    case .otherMouseDown:
+        log("button \(buttonNumber) down -> \(binding.name)")
+        postKey(binding, keyDown: true)
+        beginRepeat(for: binding)
+        return nil
+    case .otherMouseUp:
+        log("button \(buttonNumber) up -> \(binding.name)")
+        endRepeat(for: binding)
+        postKey(binding, keyDown: false)
+        return nil
+    default:
+        return Unmanaged.passUnretained(event)
+    }
+}
+
+private func runSelfTest() {
+    let expected: [Int64: CGKeyCode] = [3: 53, 4: 36, 5: 126, 6: 125]
+    precondition(bindingsByButton.count == expected.count)
+    for (button, keyCode) in expected {
+        precondition(bindingsByButton[button]?.keyCode == keyCode)
+    }
+    print("Reflectrum Dialpad mapping self-test passed.")
+}
+
+if CommandLine.arguments.contains("--self-test") {
+    runSelfTest()
+    exit(EXIT_SUCCESS)
+}
+
+let accessibilityOptions = [
+    kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true,
+] as CFDictionary
+guard AXIsProcessTrustedWithOptions(accessibilityOptions) else {
+    log("Accessibility permission is required for Reflectrum Dialpad.")
+    exit(EXIT_FAILURE)
+}
+
+let eventMask = (CGEventMask(1) << CGEventType.otherMouseDown.rawValue)
+    | (CGEventMask(1) << CGEventType.otherMouseUp.rawValue)
+
+eventTap = CGEvent.tapCreate(
+    tap: .cgSessionEventTap,
+    place: .headInsertEventTap,
+    options: .defaultTap,
+    eventsOfInterest: eventMask,
+    callback: handleEvent,
+    userInfo: nil
+)
+
+guard let eventTap else {
+    log("Input Monitoring permission is required for Reflectrum Dialpad.")
+    exit(EXIT_FAILURE)
+}
+
+let runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
+CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
+CGEvent.tapEnable(tap: eventTap, enable: true)
+log("Reflectrum Dialpad is listening for buttons 3, 4, 5, and 6.")
+CFRunLoopRun()

--- a/macos/install.sh
+++ b/macos/install.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+app_dir="$HOME/Applications/Reflectrum Dialpad.app"
+executable="$app_dir/Contents/MacOS/ReflectrumDialpad"
+launch_agent="$HOME/Library/LaunchAgents/io.reflectrum.dialpad.plist"
+log_file="$HOME/Library/Logs/Reflectrum Dialpad.log"
+build_dir=$(mktemp -d)
+trap 'rm -rf "$build_dir"' EXIT
+
+for command in codesign plutil swiftc; do
+  command -v "$command" >/dev/null 2>&1 || {
+    echo "Required command is missing: $command" >&2
+    exit 1
+  }
+done
+
+swiftc -O "$script_dir/ReflectrumDialpad.swift" -o "$build_dir/ReflectrumDialpad"
+
+install -d "$app_dir/Contents/MacOS" "$HOME/Library/LaunchAgents" "$HOME/Library/Logs"
+install -m 0755 "$build_dir/ReflectrumDialpad" "$executable"
+install -m 0644 "$script_dir/Info.plist" "$app_dir/Contents/Info.plist"
+codesign --force --sign - --identifier io.reflectrum.dialpad "$app_dir"
+
+install -m 0644 "$script_dir/io.reflectrum.dialpad.plist" "$launch_agent"
+plutil -replace ProgramArguments -json "[\"$executable\"]" "$launch_agent"
+plutil -replace StandardOutPath -string "$log_file" "$launch_agent"
+plutil -replace StandardErrorPath -string "$log_file" "$launch_agent"
+plutil -lint "$app_dir/Contents/Info.plist" "$launch_agent"
+
+launchctl bootout "gui/$UID/io.reflectrum.dialpad" >/dev/null 2>&1 || true
+launchctl bootstrap "gui/$UID" "$launch_agent"
+
+echo "Installed Reflectrum Dialpad."
+echo "If prompted, enable it in Privacy & Security > Accessibility and Input Monitoring."
+echo "Log: $log_file"

--- a/macos/io.reflectrum.dialpad.plist
+++ b/macos/io.reflectrum.dialpad.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.reflectrum.dialpad</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>REFLECTRUM_DIALPAD_EXECUTABLE</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Interactive</string>
+  <key>StandardOutPath</key>
+  <string>REFLECTRUM_DIALPAD_LOG</string>
+  <key>StandardErrorPath</key>
+  <string>REFLECTRUM_DIALPAD_LOG</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add a signed background macOS helper that maps Dialpad buttons 3-6 to Reflectrum navigation keys
- preserve press, release, and hold/repeat behavior
- install the helper as a per-user app and LaunchAgent with stable privacy permissions

## Verification
- Swift mapping self-test passes
- plist and shell validation pass
- installed helper is running and captured physical Back, Forward, and Button 6 events from the connected MX Dialpad
