### PR TITLE
Add iOS-style push and pop page transitions

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -21,6 +21,25 @@ sudo ./deploy/install.sh
 sudo reboot
 ```
 
+After the initial installation, routine work from the development Mac is one
+command per task:
+
+```sh
+npm run pi:deploy       # check, build, copy generated assets, restart kiosk
+npm run pi:refresh      # restart Chromium without rebuilding
+npm run pi:screenshare  # restore the SSH tunnel and open tuned TigerVNC
+```
+
+These commands use the `adsb` SSH host by default. Override it with
+`REFLECTRUM_PI_HOST`. Deployment intentionally leaves
+`/opt/reflectrum/reflectrum-config.js` and `/etc/reflectrum/calendar.env`
+untouched.
+
+The screen-share launcher favors responsiveness on the Raspberry Pi 3: it
+disables remote resizing, reduces Tight/JPEG quality, lowers compression work,
+and rate-limits pointer updates. Set `REFLECTRUM_VNC_LOCAL_PORT` if port 5900 is
+already used locally.
+
 The live Motorola display identifies as `HDMI-A-1`, with a preferred mode of
 1366×768 at 60 Hz. After the 90-degree Wayland transform, applications see a
 768×1366 portrait workspace.

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -38,6 +38,9 @@ install -o root -g root -m 0755 \
   "$repo_root/deploy/reflectrum-kiosk" \
   /usr/local/bin/reflectrum-kiosk
 install -o root -g root -m 0644 \
+  "$repo_root/deploy/reflectrum-kiosk.service" \
+  /etc/systemd/user/reflectrum-kiosk.service
+install -o root -g root -m 0644 \
   "$repo_root/deploy/reflectrum-kiosk.desktop" \
   /etc/xdg/autostart/reflectrum-kiosk.desktop
 install -o root -g root -m 0755 \
@@ -58,6 +61,7 @@ udevadm control --reload-rules
 modprobe uinput
 
 systemctl daemon-reload
+systemctl --global enable reflectrum-kiosk.service
 systemctl enable --now reflectrum-web.service
 
 if command -v raspi-config >/dev/null 2>&1; then

--- a/deploy/reflectrum-kiosk.desktop
+++ b/deploy/reflectrum-kiosk.desktop
@@ -2,6 +2,6 @@
 Type=Application
 Name=Reflectrum Kiosk
 Comment=Rotate the mirror display and open Reflectrum fullscreen
-Exec=/usr/local/bin/reflectrum-kiosk
+Exec=/usr/bin/systemctl --user start reflectrum-kiosk.service
 Terminal=false
 X-GNOME-Autostart-enabled=true

--- a/deploy/reflectrum-kiosk.service
+++ b/deploy/reflectrum-kiosk.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Reflectrum Chromium kiosk
+After=graphical-session.target
+PartOf=graphical-session.target
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/reflectrum/kiosk.env
+ExecStart=/usr/local/bin/reflectrum-kiosk
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=graphical-session.target

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview --host 0.0.0.0",
+    "pi:deploy": "./scripts/pi-deploy",
+    "pi:refresh": "./scripts/pi-refresh",
+    "pi:screenshare": "./scripts/pi-screenshare",
     "check": "python3 -c \"import ast, pathlib; ast.parse(pathlib.Path('deploy/reflectrum_server.py').read_text())\" && npm test && vite build",
     "test": "node --test"
   },

--- a/scripts/pi-deploy
+++ b/scripts/pi-deploy
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(dirname -- "$script_dir")
+pi_host=${REFLECTRUM_PI_HOST:-adsb}
+pi_staging=/home/pi/reflectrum-dist
+
+cd "$repo_root"
+npm run check
+
+rsync -az --delete dist/ "$pi_host:$pi_staging/"
+
+# Install only generated files. The Pi's deployment-local
+# reflectrum-config.js and private calendar environment stay untouched.
+ssh "$pi_host" "sudo install -d -o pi -g pi -m 0755 /opt/reflectrum/assets"
+ssh "$pi_host" "sudo cp -a $pi_staging/assets/. /opt/reflectrum/assets/"
+ssh "$pi_host" "sudo cp $pi_staging/index.html /opt/reflectrum/index.html"
+
+"$script_dir/pi-refresh"
+
+printf '%s\n' 'Reflectrum built, deployed, and refreshed.'

--- a/scripts/pi-refresh
+++ b/scripts/pi-refresh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+pi_host=${REFLECTRUM_PI_HOST:-adsb}
+
+if ssh "$pi_host" "systemctl --user --machine=pi@ --quiet is-active reflectrum-kiosk.service"; then
+  kiosk_unit=reflectrum-kiosk.service
+elif ssh "$pi_host" "systemctl --user --machine=pi@ --quiet is-active reflectrum-kiosk-sf.service"; then
+  kiosk_unit=reflectrum-kiosk-sf.service
+else
+  printf '%s\n' 'Reflectrum kiosk is not managed by systemd. Run deploy/install.sh on the Pi once.' >&2
+  exit 1
+fi
+
+ssh "$pi_host" "systemctl --user --machine=pi@ restart $kiosk_unit"
+printf 'Restarted %s on %s.\n' "$kiosk_unit" "$pi_host"

--- a/scripts/pi-screenshare
+++ b/scripts/pi-screenshare
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -eu
+
+pi_host=${REFLECTRUM_PI_HOST:-adsb}
+local_port=${REFLECTRUM_VNC_LOCAL_PORT:-5900}
+viewer=${REFLECTRUM_VNC_VIEWER:-/Applications/TigerVNC.app/Contents/MacOS/vncviewer}
+
+if [ ! -x "$viewer" ]; then
+  printf '%s\n' 'TigerVNC is not installed in /Applications.' >&2
+  exit 1
+fi
+
+if ! nc -z 127.0.0.1 "$local_port" >/dev/null 2>&1; then
+  ssh -f -N -T \
+    -o BatchMode=yes \
+    -o ExitOnForwardFailure=yes \
+    -o ServerAliveInterval=30 \
+    -o ServerAliveCountMax=3 \
+    -L "$local_port:127.0.0.1:5900" \
+    "$pi_host"
+fi
+
+# Tight encoding keeps text sharp while the lower JPEG quality and compression
+# levels reduce work on the Pi 3. The SSH tunnel continues to protect traffic.
+exec "$viewer" \
+  -RemoteResize=0 \
+  -PreferredEncoding=Tight \
+  -QualityLevel=5 \
+  -CompressLevel=1 \
+  -PointerEventInterval=33 \
+  "127.0.0.1::$local_port"

--- a/src/components/ViewStack.css
+++ b/src/components/ViewStack.css
@@ -1,0 +1,100 @@
+.view-stack,
+.view-stack__page {
+  width: 100%;
+  height: 100%;
+}
+
+.view-stack {
+  position: relative;
+  overflow: hidden;
+  background: #000;
+}
+
+.view-stack__page {
+  contain: layout paint;
+  view-transition-name: reflectrum-page;
+}
+
+::view-transition-group(reflectrum-page) {
+  z-index: 1;
+  overflow: hidden;
+  animation-duration: 480ms;
+  animation-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+::view-transition-image-pair(reflectrum-page) {
+  overflow: visible;
+  isolation: isolate;
+}
+
+::view-transition-old(reflectrum-page),
+::view-transition-new(reflectrum-page) {
+  height: 100%;
+  transform-origin: center center;
+  animation-duration: inherit;
+  animation-timing-function: inherit;
+  animation-fill-mode: both;
+}
+
+html[data-page-transition-direction='push']::view-transition-old(reflectrum-page) {
+  animation-name: reflectrum-push-old;
+}
+
+html[data-page-transition-direction='push']::view-transition-new(reflectrum-page) {
+  z-index: 2;
+  animation-name: reflectrum-push-new;
+  box-shadow: -24px 0 56px rgb(0 0 0 / 55%);
+}
+
+html[data-page-transition-direction='pop']::view-transition-old(reflectrum-page) {
+  z-index: 2;
+  animation-name: reflectrum-pop-old;
+  box-shadow: -24px 0 56px rgb(0 0 0 / 55%);
+}
+
+html[data-page-transition-direction='pop']::view-transition-new(reflectrum-page) {
+  animation-name: reflectrum-pop-new;
+}
+
+@keyframes reflectrum-push-old {
+  from {
+    transform: translateX(0) scale(1);
+    filter: brightness(1);
+  }
+  to {
+    transform: translateX(-28%) scale(0.96);
+    filter: brightness(0.72);
+  }
+}
+
+@keyframes reflectrum-push-new {
+  from { transform: translateX(100%); }
+  to { transform: translateX(0); }
+}
+
+@keyframes reflectrum-pop-old {
+  from { transform: translateX(0); }
+  to { transform: translateX(100%); }
+}
+
+@keyframes reflectrum-pop-new {
+  from {
+    transform: translateX(-28%) scale(0.96);
+    filter: brightness(0.72);
+  }
+  to {
+    transform: translateX(0) scale(1);
+    filter: brightness(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(reflectrum-page) {
+    animation-duration: 1ms;
+  }
+
+  ::view-transition-old(reflectrum-page),
+  ::view-transition-new(reflectrum-page) {
+    animation-name: none !important;
+  }
+}

--- a/src/components/ViewStack.css
+++ b/src/components/ViewStack.css
@@ -11,6 +11,7 @@
 }
 
 .view-stack__page {
+  background: #000;
   contain: layout paint;
   view-transition-name: reflectrum-page;
 }
@@ -29,7 +30,9 @@
 
 ::view-transition-old(reflectrum-page),
 ::view-transition-new(reflectrum-page) {
+  background: #000;
   height: 100%;
+  mix-blend-mode: normal;
   transform-origin: center center;
   animation-duration: inherit;
   animation-timing-function: inherit;
@@ -43,7 +46,7 @@ html[data-page-transition-direction='push']::view-transition-old(reflectrum-page
 html[data-page-transition-direction='push']::view-transition-new(reflectrum-page) {
   z-index: 2;
   animation-name: reflectrum-push-new;
-  box-shadow: 24px 0 56px rgb(0 0 0 / 55%);
+  box-shadow: -24px 0 56px rgb(0 0 0 / 55%);
 }
 
 html[data-page-transition-direction='pop']::view-transition-old(reflectrum-page) {
@@ -62,13 +65,13 @@ html[data-page-transition-direction='pop']::view-transition-new(reflectrum-page)
     filter: brightness(1);
   }
   to {
-    transform: translateX(28%) scale(0.96);
+    transform: translateX(-28%) scale(0.96);
     filter: brightness(0.72);
   }
 }
 
 @keyframes reflectrum-push-new {
-  from { transform: translateX(-100%); }
+  from { transform: translateX(100%); }
   to { transform: translateX(0); }
 }
 

--- a/src/components/ViewStack.css
+++ b/src/components/ViewStack.css
@@ -43,7 +43,7 @@ html[data-page-transition-direction='push']::view-transition-old(reflectrum-page
 html[data-page-transition-direction='push']::view-transition-new(reflectrum-page) {
   z-index: 2;
   animation-name: reflectrum-push-new;
-  box-shadow: -24px 0 56px rgb(0 0 0 / 55%);
+  box-shadow: 24px 0 56px rgb(0 0 0 / 55%);
 }
 
 html[data-page-transition-direction='pop']::view-transition-old(reflectrum-page) {
@@ -62,13 +62,13 @@ html[data-page-transition-direction='pop']::view-transition-new(reflectrum-page)
     filter: brightness(1);
   }
   to {
-    transform: translateX(-28%) scale(0.96);
+    transform: translateX(28%) scale(0.96);
     filter: brightness(0.72);
   }
 }
 
 @keyframes reflectrum-push-new {
-  from { transform: translateX(100%); }
+  from { transform: translateX(-100%); }
   to { transform: translateX(0); }
 }
 

--- a/src/components/ViewStack.jsx
+++ b/src/components/ViewStack.jsx
@@ -3,6 +3,7 @@ import {pages} from '../helpers/pages.jsx';
 
 import { StandbyContainer } from './Standby.jsx';
 import { connect } from 'react-redux';
+import './ViewStack.css';
 class ViewStack extends Component {
 
   render() {
@@ -11,8 +12,10 @@ class ViewStack extends Component {
     console.log("ViewStack", pages, activePageName)
 
     return (
-      <div>
-        {pages[activePageName]}
+      <div className="view-stack">
+        <div className="view-stack__page">
+          {pages[activePageName]}
+        </div>
         <StandbyContainer />
       </div>
     )

--- a/src/components/calendar/calendar.css
+++ b/src/components/calendar/calendar.css
@@ -45,8 +45,8 @@
 
 .calendar-event {
   display: grid;
-  grid-template-columns: 205px 1fr;
-  gap: 28px;
+  grid-template-columns: 235px 1fr;
+  gap: 22px;
   padding: 22px 0;
   border-top: 1px solid #3d3d48;
 }
@@ -54,6 +54,7 @@
 .calendar-event-time {
   color: #ff6258;
   font-size: 25px;
+  white-space: nowrap;
 }
 
 .calendar-event-body {

--- a/src/components/calendar/calendar.jsx
+++ b/src/components/calendar/calendar.jsx
@@ -8,14 +8,34 @@ const dateLabel = (date) => new Intl.DateTimeFormat(undefined, {
   weekday: 'long', month: 'short', day: 'numeric',
 }).format(date);
 
-const timeLabel = (date) => new Intl.DateTimeFormat(undefined, {
-  hour: 'numeric', minute: '2-digit',
-}).format(date);
+const timeFormatter = new Intl.DateTimeFormat('en-US', {
+  hour: 'numeric', minute: '2-digit', hour12: true,
+});
+
+const timeParts = (date) => {
+  const parts = timeFormatter.formatToParts(date);
+  return {
+    time: parts
+      .filter(({ type }) => type !== 'dayPeriod')
+      .map(({ value }) => value)
+      .join('')
+      .trim(),
+    period: parts.find(({ type }) => type === 'dayPeriod').value,
+  };
+};
+
+const timeRangeLabel = (start, end) => {
+  const startTime = timeParts(start);
+  const endTime = timeParts(end);
+  return startTime.period === endTime.period
+    ? `${startTime.time}–${endTime.time} ${endTime.period}`
+    : `${startTime.time} ${startTime.period}–${endTime.time} ${endTime.period}`;
+};
 
 const Event = ({ event }) => (
   <li className="calendar-event">
     <div className="calendar-event-time">
-      {event.allDay ? 'All day' : `${timeLabel(event.start)}–${timeLabel(event.end)}`}
+      {event.allDay ? 'All day' : timeRangeLabel(event.start, event.end)}
     </div>
     <div className="calendar-event-body">
       <strong>{event.summary}</strong>

--- a/src/components/menu/MenuList.jsx
+++ b/src/components/menu/MenuList.jsx
@@ -10,7 +10,7 @@ class MenuList extends Component {
     return (
         <div className="menu-list">
           <MenuListSelectedItem selectedItem={props.selectedItem} className="menu-list-select-item" />
-          <div className="animated fadeInLeft">
+          <div>
           {
             props.items.map(function(item){
               return (

--- a/src/components/menu/MenuListSelectedItem.jsx
+++ b/src/components/menu/MenuListSelectedItem.jsx
@@ -6,7 +6,7 @@ class MenuListSelectedItem extends Component {
     const top = props.selectedItem * 200 + 'px'
 
     return (
-      <div style={{top: top}} className="animated slideInRight menu-list-select-item"></div>
+      <div style={{top: top}} className="menu-list-select-item"></div>
     )
   }
 }

--- a/src/helpers/pageTransitions.js
+++ b/src/helpers/pageTransitions.js
@@ -1,0 +1,46 @@
+import { flushSync } from 'react-dom';
+
+let activeTransition = null;
+
+export const navigationDirection = (action, state) => {
+  if (state.standby) return null;
+  if (action.type === 'BACK') return state.history.length > 1 ? 'pop' : null;
+  if (action.type === 'OPEN_ITEM' && action.page) return 'push';
+  if (action.type === 'OPEN_MAIN_MENU') return 'push';
+  return null;
+};
+
+export const pageTransitionMiddleware = ({ getState }) => (next) => (action) => {
+  const direction = navigationDirection(action, getState());
+  if (!direction || typeof document === 'undefined' || typeof document.startViewTransition !== 'function') {
+    return next(action);
+  }
+
+  activeTransition?.skipTransition();
+  document.documentElement.dataset.pageTransitionDirection = direction;
+
+  let result = action;
+  let didDispatch = false;
+  try {
+    const transition = document.startViewTransition(() => {
+      flushSync(() => {
+        result = next(action);
+        didDispatch = true;
+      });
+    });
+    activeTransition = transition;
+    const finishTransition = () => {
+      if (activeTransition === transition) {
+        activeTransition = null;
+        delete document.documentElement.dataset.pageTransitionDirection;
+      }
+    };
+    transition.finished.then(finishTransition, finishTransition);
+  } catch (error) {
+    delete document.documentElement.dataset.pageTransitionDirection;
+    console.warn('Page transition failed:', error.message);
+    return didDispatch ? result : next(action);
+  }
+
+  return result;
+};

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { createStore } from 'redux';
+import { applyMiddleware, createStore } from 'redux';
 import { Provider } from 'react-redux';
 import ViewStack from './components/ViewStack.jsx';
 import InputDiagnostics from './components/InputDiagnostics.jsx';
 import { mainMenu } from './components/MainMenu.jsx';
 import moment from 'moment';
+import { pageTransitionMiddleware } from './helpers/pageTransitions.js';
 import './base.css';
 
 
@@ -168,7 +169,7 @@ const reflectrumApp = (state = data, action) => {
 
 
 createRoot(document.getElementById('target')).render(
-  <Provider store={createStore(reflectrumApp)}>
+  <Provider store={createStore(reflectrumApp, applyMiddleware(pageTransitionMiddleware))}>
     <ViewStack/>
     <InputDiagnostics/>
   </Provider>

--- a/test/pageTransitions.test.js
+++ b/test/pageTransitions.test.js
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  navigationDirection,
+  pageTransitionMiddleware,
+} from '../src/helpers/pageTransitions.js';
+
+const state = {
+  history: ['MAIN_MENU', 'WEATHER'],
+  standby: false,
+};
+
+test('marks forward navigation as a push transition', () => {
+  assert.equal(navigationDirection({ type: 'OPEN_ITEM', page: 'WEATHER' }, state), 'push');
+  assert.equal(navigationDirection({ type: 'OPEN_MAIN_MENU' }, state), 'push');
+});
+
+test('marks back navigation as pop only when history can pop', () => {
+  assert.equal(navigationDirection({ type: 'BACK' }, state), 'pop');
+  assert.equal(navigationDirection({ type: 'BACK' }, { ...state, history: ['MAIN_MENU'] }), null);
+});
+
+test('does not transition unrelated or standby actions', () => {
+  assert.equal(navigationDirection({ type: 'SCROLL_DOWN' }, state), null);
+  assert.equal(navigationDirection({ type: 'OPEN_ITEM', page: 'WEATHER' }, { ...state, standby: true }), null);
+});
+
+test('dispatches normally when the View Transitions API is unavailable', () => {
+  const action = { type: 'OPEN_ITEM', page: 'WEATHER' };
+  const dispatch = pageTransitionMiddleware({ getState: () => state })((received) => {
+    assert.equal(received, action);
+    return 'dispatched';
+  });
+
+  assert.equal(dispatch(action), 'dispatched');
+});
+
+test('sets and clears the push direction around a view transition', async () => {
+  const originalDocument = globalThis.document;
+  const action = { type: 'OPEN_ITEM', page: 'WEATHER' };
+  const dataset = {};
+
+  globalThis.document = {
+    documentElement: { dataset },
+    startViewTransition(update) {
+      update();
+      return {
+        finished: Promise.resolve(),
+        skipTransition() {},
+      };
+    },
+  };
+
+  try {
+    const dispatch = pageTransitionMiddleware({ getState: () => state })(() => 'transitioned');
+    assert.equal(dispatch(action), 'transitioned');
+    assert.equal(dataset.pageTransitionDirection, 'push');
+    await Promise.resolve();
+    assert.equal(dataset.pageTransitionDirection, undefined);
+  } finally {
+    if (originalDocument === undefined) delete globalThis.document;
+    else globalThis.document = originalDocument;
+  }
+});


### PR DESCRIPTION
## Summary
- animate forward navigation as a layered push with depth, dimming, and a trailing shadow
- reverse the motion for Back navigation so the previous page returns naturally
- preserve synchronous Redux updates inside the View Transitions API, with safe fallback behavior
- respect reduced-motion preferences

## Verification
- npm run check
- 13 tests pass
- Vite production build succeeds
- git diff --check