### PR TITLE
Add Pi operations and polish calendar times

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -21,6 +21,25 @@ sudo ./deploy/install.sh
 sudo reboot
 ```
 
+After the initial installation, routine work from the development Mac is one
+command per task:
+
+```sh
+npm run pi:deploy       # check, build, copy generated assets, restart kiosk
+npm run pi:refresh      # restart Chromium without rebuilding
+npm run pi:screenshare  # restore the SSH tunnel and open tuned TigerVNC
+```
+
+These commands use the `adsb` SSH host by default. Override it with
+`REFLECTRUM_PI_HOST`. Deployment intentionally leaves
+`/opt/reflectrum/reflectrum-config.js` and `/etc/reflectrum/calendar.env`
+untouched.
+
+The screen-share launcher favors responsiveness on the Raspberry Pi 3: it
+disables remote resizing, reduces Tight/JPEG quality, lowers compression work,
+and rate-limits pointer updates. Set `REFLECTRUM_VNC_LOCAL_PORT` if port 5900 is
+already used locally.
+
 The live Motorola display identifies as `HDMI-A-1`, with a preferred mode of
 1366×768 at 60 Hz. After the 90-degree Wayland transform, applications see a
 768×1366 portrait workspace.

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -38,6 +38,9 @@ install -o root -g root -m 0755 \
   "$repo_root/deploy/reflectrum-kiosk" \
   /usr/local/bin/reflectrum-kiosk
 install -o root -g root -m 0644 \
+  "$repo_root/deploy/reflectrum-kiosk.service" \
+  /etc/systemd/user/reflectrum-kiosk.service
+install -o root -g root -m 0644 \
   "$repo_root/deploy/reflectrum-kiosk.desktop" \
   /etc/xdg/autostart/reflectrum-kiosk.desktop
 install -o root -g root -m 0755 \
@@ -58,6 +61,7 @@ udevadm control --reload-rules
 modprobe uinput
 
 systemctl daemon-reload
+systemctl --global enable reflectrum-kiosk.service
 systemctl enable --now reflectrum-web.service
 
 if command -v raspi-config >/dev/null 2>&1; then

--- a/deploy/reflectrum-kiosk.desktop
+++ b/deploy/reflectrum-kiosk.desktop
@@ -2,6 +2,6 @@
 Type=Application
 Name=Reflectrum Kiosk
 Comment=Rotate the mirror display and open Reflectrum fullscreen
-Exec=/usr/local/bin/reflectrum-kiosk
+Exec=/usr/bin/systemctl --user start reflectrum-kiosk.service
 Terminal=false
 X-GNOME-Autostart-enabled=true

--- a/deploy/reflectrum-kiosk.service
+++ b/deploy/reflectrum-kiosk.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Reflectrum Chromium kiosk
+After=graphical-session.target
+PartOf=graphical-session.target
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/reflectrum/kiosk.env
+ExecStart=/usr/local/bin/reflectrum-kiosk
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=graphical-session.target

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview --host 0.0.0.0",
+    "pi:deploy": "./scripts/pi-deploy",
+    "pi:refresh": "./scripts/pi-refresh",
+    "pi:screenshare": "./scripts/pi-screenshare",
     "check": "python3 -c \"import ast, pathlib; ast.parse(pathlib.Path('deploy/reflectrum_server.py').read_text())\" && npm test && vite build",
     "test": "node --test"
   },

--- a/scripts/pi-deploy
+++ b/scripts/pi-deploy
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(dirname -- "$script_dir")
+pi_host=${REFLECTRUM_PI_HOST:-adsb}
+pi_staging=/home/pi/reflectrum-dist
+
+cd "$repo_root"
+npm run check
+
+rsync -az --delete dist/ "$pi_host:$pi_staging/"
+
+# Install only generated files. The Pi's deployment-local
+# reflectrum-config.js and private calendar environment stay untouched.
+ssh "$pi_host" "sudo install -d -o pi -g pi -m 0755 /opt/reflectrum/assets"
+ssh "$pi_host" "sudo cp -a $pi_staging/assets/. /opt/reflectrum/assets/"
+ssh "$pi_host" "sudo cp $pi_staging/index.html /opt/reflectrum/index.html"
+
+"$script_dir/pi-refresh"
+
+printf '%s\n' 'Reflectrum built, deployed, and refreshed.'

--- a/scripts/pi-refresh
+++ b/scripts/pi-refresh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+pi_host=${REFLECTRUM_PI_HOST:-adsb}
+
+if ssh "$pi_host" "systemctl --user --machine=pi@ --quiet is-active reflectrum-kiosk.service"; then
+  kiosk_unit=reflectrum-kiosk.service
+elif ssh "$pi_host" "systemctl --user --machine=pi@ --quiet is-active reflectrum-kiosk-sf.service"; then
+  kiosk_unit=reflectrum-kiosk-sf.service
+else
+  printf '%s\n' 'Reflectrum kiosk is not managed by systemd. Run deploy/install.sh on the Pi once.' >&2
+  exit 1
+fi
+
+ssh "$pi_host" "systemctl --user --machine=pi@ restart $kiosk_unit"
+printf 'Restarted %s on %s.\n' "$kiosk_unit" "$pi_host"

--- a/scripts/pi-screenshare
+++ b/scripts/pi-screenshare
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -eu
+
+pi_host=${REFLECTRUM_PI_HOST:-adsb}
+local_port=${REFLECTRUM_VNC_LOCAL_PORT:-5900}
+viewer=${REFLECTRUM_VNC_VIEWER:-/Applications/TigerVNC.app/Contents/MacOS/vncviewer}
+
+if [ ! -x "$viewer" ]; then
+  printf '%s\n' 'TigerVNC is not installed in /Applications.' >&2
+  exit 1
+fi
+
+if ! nc -z 127.0.0.1 "$local_port" >/dev/null 2>&1; then
+  ssh -f -N -T \
+    -o BatchMode=yes \
+    -o ExitOnForwardFailure=yes \
+    -o ServerAliveInterval=30 \
+    -o ServerAliveCountMax=3 \
+    -L "$local_port:127.0.0.1:5900" \
+    "$pi_host"
+fi
+
+# Tight encoding keeps text sharp while the lower JPEG quality and compression
+# levels reduce work on the Pi 3. The SSH tunnel continues to protect traffic.
+exec "$viewer" \
+  -RemoteResize=0 \
+  -PreferredEncoding=Tight \
+  -QualityLevel=5 \
+  -CompressLevel=1 \
+  -PointerEventInterval=33 \
+  "127.0.0.1::$local_port"

--- a/src/components/calendar/calendar.css
+++ b/src/components/calendar/calendar.css
@@ -45,8 +45,8 @@
 
 .calendar-event {
   display: grid;
-  grid-template-columns: 205px 1fr;
-  gap: 28px;
+  grid-template-columns: 235px 1fr;
+  gap: 22px;
   padding: 22px 0;
   border-top: 1px solid #3d3d48;
 }
@@ -54,6 +54,7 @@
 .calendar-event-time {
   color: #ff6258;
   font-size: 25px;
+  white-space: nowrap;
 }
 
 .calendar-event-body {

--- a/src/components/calendar/calendar.jsx
+++ b/src/components/calendar/calendar.jsx
@@ -8,14 +8,34 @@ const dateLabel = (date) => new Intl.DateTimeFormat(undefined, {
   weekday: 'long', month: 'short', day: 'numeric',
 }).format(date);
 
-const timeLabel = (date) => new Intl.DateTimeFormat(undefined, {
-  hour: 'numeric', minute: '2-digit',
-}).format(date);
+const timeFormatter = new Intl.DateTimeFormat('en-US', {
+  hour: 'numeric', minute: '2-digit', hour12: true,
+});
+
+const timeParts = (date) => {
+  const parts = timeFormatter.formatToParts(date);
+  return {
+    time: parts
+      .filter(({ type }) => type !== 'dayPeriod')
+      .map(({ value }) => value)
+      .join('')
+      .trim(),
+    period: parts.find(({ type }) => type === 'dayPeriod').value,
+  };
+};
+
+const timeRangeLabel = (start, end) => {
+  const startTime = timeParts(start);
+  const endTime = timeParts(end);
+  return startTime.period === endTime.period
+    ? `${startTime.time}–${endTime.time} ${endTime.period}`
+    : `${startTime.time} ${startTime.period}–${endTime.time} ${endTime.period}`;
+};
 
 const Event = ({ event }) => (
   <li className="calendar-event">
     <div className="calendar-event-time">
-      {event.allDay ? 'All day' : `${timeLabel(event.start)}–${timeLabel(event.end)}`}
+      {event.allDay ? 'All day' : timeRangeLabel(event.start, event.end)}
     </div>
     <div className="calendar-event-body">
       <strong>{event.summary}</strong>


### PR DESCRIPTION
## Summary
- format calendar ranges explicitly in compact 12-hour time and prevent wrapping
- add safe one-command Pi build/deploy and kiosk refresh workflows
- add a tuned, keepalive-backed TigerVNC launcher for the Raspberry Pi 3
- manage Chromium with a persistent systemd user service
- preserve deployment-local weather and private calendar configuration

## Verification
- npm run check (13 tests and Vite production build)
- shell syntax and plist validation
- npm run pi:deploy exercised end to end on the Raspberry Pi
- npm run pi:refresh exercised against the persistent kiosk service
- npm run pi:screenshare opened an authenticated tuned TigerVNC session
- 12-hour calendar layout visually verified on the portrait Pi display

## Stack
Depends on #24.