### PR TITLE
Add Pi runtime services and resilient tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ that appear as unusual function keys can be mapped without rebuilding:
 window.REFLECTRUM_CONFIG = {
   input: {
     keyMap: {
-      F13: 'UP_CLICK',
+      F13: 'DISPLAY_TOGGLE',
       F14: 'DOWN_CLICK',
       F15: 'PRIMARY_CLICK',
       F16: 'SECONDARY_CLICK',
@@ -88,6 +88,11 @@ Weather uses the keyless Open-Meteo forecast API. When no location is
 configured, Reflectrum asks the browser for its current position. Calendar
 reads a private iCalendar feed through the loopback-only Pi service; see
 [deploy/README.md](deploy/README.md#calendar-feed).
+
+Night Shift runs at the Raspberry Pi compositor level, outside Chromium, so
+navigation and browser refreshes cannot interrupt the tint. Its location and
+color temperatures are deployment settings documented in
+[deploy/README.md](deploy/README.md#night-shift).
 
 ## Raspberry Pi kiosk
 

--- a/deploy/50-reflectrum-power.rules
+++ b/deploy/50-reflectrum-power.rules
@@ -1,0 +1,12 @@
+polkit.addRule(function(action, subject) {
+    var reflectrumPowerActions = [
+        "org.freedesktop.login1.reboot",
+        "org.freedesktop.login1.reboot-multiple-sessions",
+        "org.freedesktop.login1.power-off",
+        "org.freedesktop.login1.power-off-multiple-sessions"
+    ];
+
+    if (subject.user === "pi" && reflectrumPowerActions.indexOf(action.id) !== -1) {
+        return polkit.Result.YES;
+    }
+});

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -6,6 +6,8 @@ Reflectrum coexists with the FlightAware feeder:
 - `reflectrum-web.service` serves the static build on loopback port 3000.
 - the desktop autostart entry rotates `HDMI-A-1` 90 degrees with `wlr-randr`
   and opens Chromium in kiosk mode.
+- `wlsunset` adjusts display color temperature through labwc's Wayland gamma
+  controls; Night Shift is not rendered inside Chromium.
 
 Build on a development computer so the Pi does not need Node.js:
 
@@ -30,7 +32,13 @@ npm run pi:refresh      # restart Chromium without rebuilding
 npm run pi:screenshare  # restore the SSH tunnel and open tuned TigerVNC
 ```
 
-These commands use the `adsb` SSH host by default. Override it with
+`pi:deploy` also installs the tracked loopback server, systemd units, and Solaar
+rules while preserving all deployment-local config and secret environment files.
+Reboot once when the Dialpad rule changes so the running Solaar session reloads
+it.
+
+These commands use the Raspberry Pi's `adsb.local` mDNS name by default, so
+DHCP address changes do not require script updates. Override it with
 `REFLECTRUM_PI_HOST`. Deployment intentionally leaves
 `/opt/reflectrum/reflectrum-config.js` and `/etc/reflectrum/calendar.env`
 untouched.
@@ -44,9 +52,48 @@ The live Motorola display identifies as `HDMI-A-1`, with a preferred mode of
 1366×768 at 60 Hz. After the 90-degree Wayland transform, applications see a
 768×1366 portrait workspace.
 
+## System settings
+
+The Settings page exposes guarded reboot and shutdown actions. Each action
+requires two select presses, and Back cancels the confirmation. The browser can
+only POST `reboot` or `shutdown` to the loopback server. The tracked polkit rule
+allows the `pi` kiosk account only the matching logind power actions; it does not
+grant shell or general sudo access.
+
 Override the output, rotation, or URL by setting `REFLECTRUM_OUTPUT`,
 `REFLECTRUM_ROTATION`, or `REFLECTRUM_URL` in the graphical session before the
 autostart entry runs.
+
+## Night Shift
+
+Install the Bookworm `wlsunset` package before the initial Reflectrum install:
+
+```sh
+sudo apt install wlsunset
+```
+
+The `reflectrum-night-shift` user service talks directly to labwc's
+`wlr-gamma-control` interface. It defaults to San Francisco (`37.8`, `-122.4`),
+6500 K during the day, and 4000 K at night. Solar elevation controls the smooth
+transition, so page changes and Chromium refreshes cannot interrupt the tint.
+The desktop autostart entry starts the service whenever the kiosk session logs
+in, including after a reboot.
+
+Override the defaults in `/etc/reflectrum/night-shift.env`:
+
+```ini
+REFLECTRUM_NIGHT_SHIFT_LATITUDE=37.8
+REFLECTRUM_NIGHT_SHIFT_LONGITUDE=-122.4
+REFLECTRUM_NIGHT_SHIFT_DAY_TEMPERATURE=6500
+REFLECTRUM_NIGHT_SHIFT_NIGHT_TEMPERATURE=4000
+```
+
+Then reload it inside the graphical session:
+
+```sh
+systemctl --user restart reflectrum-night-shift.service
+systemctl --user status reflectrum-night-shift.service
+```
 
 Useful diagnostics:
 
@@ -83,6 +130,56 @@ sudo systemctl restart reflectrum-web
 
 Chromium requests `/api/calendar`, so the private feed URL is never stored in
 the static application.
+
+## Linear assigned tasks
+
+Create a personal API key in Linear and keep it in a root-owned environment
+file; the key must never be placed in the static runtime config or repository.
+
+```sh
+sudoedit /etc/reflectrum/linear.env
+```
+
+Add the secret and restart the loopback service:
+
+```ini
+REFLECTRUM_LINEAR_API_KEY=lin_api_replace_me
+```
+
+```sh
+sudo chmod 600 /etc/reflectrum/linear.env
+sudo systemctl restart reflectrum-web
+```
+
+The Linear page lists active issues assigned to the key owner. Select opens a
+confirmation card; select a second time completes the issue, while back cancels.
+The server verifies ownership again immediately before the update.
+
+## Home Assistant dashboard
+
+Reflectrum's Home page is read-only. It auto-groups locks, lights, sensors, and
+network-related entities, and requests numeric history for small trend lines.
+Create a long-lived Home Assistant access token and store the URL and token only
+on the Pi:
+
+```sh
+sudoedit /etc/reflectrum/home-assistant.env
+```
+
+```ini
+REFLECTRUM_HOME_ASSISTANT_URL=http://home-assistant-host:8123
+REFLECTRUM_HOME_ASSISTANT_TOKEN=replace_with_a_long_lived_token
+```
+
+```sh
+sudo chmod 600 /etc/reflectrum/home-assistant.env
+sudo systemctl restart reflectrum-web
+```
+
+The loopback service returns only allowlisted state fields and exposes no Home
+Assistant mutation route. To put specific numeric entities first in the history
+request, add their entity IDs to `homeAssistant.historyEntities` in the Pi's
+untracked `reflectrum-config.js`.
 
 ## Logitech MX Creative Dialpad
 
@@ -135,7 +232,7 @@ buttons as diverted, and applies these rules:
 | --- | --- |
 | Back Button | Back |
 | Forward Button | Select/forward |
-| Button 6 | Previous item |
+| Button 6 | Fade and toggle physical display power |
 | Left Scroll As Button 7 | Next item |
 
 The installer also adds Solaar's version-pinned `uinput` udev rule so these
@@ -151,3 +248,15 @@ sudo evtest
 
 Solaar handles the vendor HID++ buttons outside the browser, avoiding WebHID's
 interactive permission prompt. Reflectrum itself remains device-independent.
+
+Button 6 emits `F13`, which Reflectrum reserves for display power. The app fades
+to black before asking the loopback service to disable the live Wayland output,
+and enables HDMI with its 90-degree transform before revealing the UI. Older
+non-Wayland Pi images fall back to `vcgencmd`. Other navigation input is ignored
+while the display is off. Override the defaults with
+`REFLECTRUM_DISPLAY_OUTPUT` and `REFLECTRUM_DISPLAY_ROTATION` in a service
+environment file. Test the service directly with:
+
+```sh
+curl http://127.0.0.1:3000/api/display
+```

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -15,7 +15,7 @@ if [[ ! -f $source_dir/index.html ]]; then
   exit 1
 fi
 
-for command in chromium curl python3 solaar wlr-randr; do
+for command in chromium curl python3 solaar wlr-randr wlsunset; do
   command -v "$command" >/dev/null 2>&1 || {
     echo "Required command is missing: $command" >&2
     exit 1
@@ -40,6 +40,15 @@ install -o root -g root -m 0755 \
 install -o root -g root -m 0644 \
   "$repo_root/deploy/reflectrum-kiosk.service" \
   /etc/systemd/user/reflectrum-kiosk.service
+install -o root -g root -m 0755 \
+  "$repo_root/deploy/reflectrum-night-shift" \
+  /usr/local/bin/reflectrum-night-shift
+install -o root -g root -m 0644 \
+  "$repo_root/deploy/reflectrum-night-shift.service" \
+  /etc/systemd/user/reflectrum-night-shift.service
+install -o root -g root -m 0644 \
+  "$repo_root/deploy/reflectrum-night-shift.desktop" \
+  /etc/xdg/autostart/reflectrum-night-shift.desktop
 install -o root -g root -m 0644 \
   "$repo_root/deploy/reflectrum-kiosk.desktop" \
   /etc/xdg/autostart/reflectrum-kiosk.desktop
@@ -57,11 +66,15 @@ install -o pi -g pi -m 0644 \
 install -o root -g root -m 0644 \
   "$repo_root/deploy/42-reflectrum-logitech-permissions.rules" \
   /etc/udev/rules.d/42-reflectrum-logitech-permissions.rules
+install -o root -g root -m 0644 \
+  "$repo_root/deploy/50-reflectrum-power.rules" \
+  /etc/polkit-1/rules.d/50-reflectrum-power.rules
 udevadm control --reload-rules
 modprobe uinput
 
 systemctl daemon-reload
 systemctl --global enable reflectrum-kiosk.service
+systemctl --global enable reflectrum-night-shift.service
 systemctl enable --now reflectrum-web.service
 
 if command -v raspi-config >/dev/null 2>&1; then

--- a/deploy/reflectrum-night-shift
+++ b/deploy/reflectrum-night-shift
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eu
+
+latitude=${REFLECTRUM_NIGHT_SHIFT_LATITUDE:-37.8}
+longitude=${REFLECTRUM_NIGHT_SHIFT_LONGITUDE:--122.4}
+day_temperature=${REFLECTRUM_NIGHT_SHIFT_DAY_TEMPERATURE:-6500}
+night_temperature=${REFLECTRUM_NIGHT_SHIFT_NIGHT_TEMPERATURE:-4000}
+
+if ! command -v wlsunset >/dev/null 2>&1; then
+  logger -t reflectrum 'wlsunset is not installed'
+  exit 1
+fi
+
+exec wlsunset \
+  -l "$latitude" \
+  -L "$longitude" \
+  -T "$day_temperature" \
+  -t "$night_temperature"

--- a/deploy/reflectrum-night-shift.desktop
+++ b/deploy/reflectrum-night-shift.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=Reflectrum Night Shift
+Comment=Start compositor-level display color temperature control
+Exec=/usr/bin/systemctl --user start reflectrum-night-shift.service
+Terminal=false
+X-GNOME-Autostart-enabled=true

--- a/deploy/reflectrum-night-shift.service
+++ b/deploy/reflectrum-night-shift.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Reflectrum compositor-level Night Shift
+After=graphical-session.target
+PartOf=graphical-session.target
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/reflectrum/night-shift.env
+ExecStart=/usr/local/bin/reflectrum-night-shift
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=graphical-session.target

--- a/deploy/reflectrum-solaar-rules.yaml
+++ b/deploy/reflectrum-solaar-rules.yaml
@@ -9,7 +9,7 @@
 ...
 ---
 - Key: [Button 6, pressed]
-- KeyPress: Up
+- KeyPress: F13
 ...
 ---
 - Key: [Left Scroll As Button 7, pressed]

--- a/deploy/reflectrum-web.service
+++ b/deploy/reflectrum-web.service
@@ -7,12 +7,16 @@ Type=simple
 User=pi
 Group=pi
 EnvironmentFile=-/etc/reflectrum/calendar.env
+EnvironmentFile=-/etc/reflectrum/linear.env
+EnvironmentFile=-/etc/reflectrum/home-assistant.env
 ExecStart=/usr/bin/python3 /usr/local/lib/reflectrum/reflectrum_server.py --bind 127.0.0.1 --port 3000 --directory /opt/reflectrum
 Restart=on-failure
 RestartSec=3
 NoNewPrivileges=true
 PrivateTmp=true
-ProtectHome=true
+# The Wayland socket lives under /run/user/1000. Keep home paths read-only
+# while allowing the loopback service to connect to that existing socket.
+ProtectHome=read-only
 ProtectSystem=strict
 
 [Install]

--- a/deploy/reflectrum_server.py
+++ b/deploy/reflectrum_server.py
@@ -2,30 +2,475 @@
 import argparse
 import json
 import os
+import shutil
+import subprocess
+import threading
+import time
+import re
+from datetime import datetime, timedelta, timezone
 from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlsplit
+from urllib.parse import parse_qs, quote, urlencode, urlsplit
 from urllib.request import Request, urlopen
 
 MAX_CALENDAR_BYTES = 5 * 1024 * 1024
+MAX_JSON_BYTES = 1024
+MAX_LINEAR_BYTES = 2 * 1024 * 1024
+MAX_HOME_ASSISTANT_BYTES = 10 * 1024 * 1024
+LINEAR_API_URL = "https://api.linear.app/graphql"
+LINEAR_CACHE_SECONDS = 60
+LINEAR_CACHE = {"issues": None, "stored_at": 0}
+LINEAR_CACHE_LOCK = threading.Lock()
+HOME_ENTITY_PATTERN = re.compile(r"^[a-z0-9_]+\.[a-z0-9_]+$")
+HOME_STATES_CACHE = {"states": None, "stored_at": 0}
+HOME_STATES_CACHE_LOCK = threading.Lock()
+DISPLAY_POWER_LOCK = threading.Lock()
+SYSTEM_POWER_COMMANDS = {
+    "reboot": "reboot",
+    "shutdown": "poweroff",
+}
 
 
 class ReflectrumHandler(SimpleHTTPRequestHandler):
     def do_GET(self):
-        if urlsplit(self.path).path == "/api/calendar":
+        path = urlsplit(self.path).path
+        if path == "/api/calendar":
             self.serve_calendar()
+            return
+        if path == "/api/display":
+            self.serve_display_status()
+            return
+        if path == "/api/linear/issues":
+            self.serve_linear_issues()
+            return
+        if path == "/api/home/states":
+            self.serve_home_states()
+            return
+        if path == "/api/home/history":
+            self.serve_home_history()
             return
         super().do_GET()
 
-    def send_json_error(self, status, message):
-        payload = json.dumps({"error": message}).encode("utf-8")
+    def do_POST(self):
+        path = urlsplit(self.path).path
+        if path == "/api/display":
+            self.set_display_power()
+            return
+        if path == "/api/system/power":
+            self.set_system_power()
+            return
+        if path == "/api/linear/issues/complete":
+            self.complete_linear_issue()
+            return
+        self.send_json_error(404, "Not found.")
+
+    def send_json(self, status, value):
+        payload = json.dumps(value).encode("utf-8")
         self.send_response(status)
         self.send_header("Content-Type", "application/json; charset=utf-8")
         self.send_header("Content-Length", str(len(payload)))
         self.send_header("Cache-Control", "no-store")
         self.end_headers()
         self.wfile.write(payload)
+
+    def send_json_error(self, status, message):
+        self.send_json(status, {"error": message})
+
+    def same_origin_request(self):
+        origin = self.headers.get("Origin")
+        host = self.headers.get("Host")
+        return not origin or urlsplit(origin).netloc == host
+
+    def read_json_request(self):
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            raise ValueError("Invalid request size.")
+        if length < 1 or length > MAX_JSON_BYTES:
+            raise ValueError("Invalid request size.")
+        try:
+            return json.loads(self.rfile.read(length))
+        except (json.JSONDecodeError, UnicodeDecodeError) as error:
+            raise ValueError("Invalid JSON request.") from error
+
+    def linear_graphql(self, query, variables=None):
+        api_key = os.environ.get("REFLECTRUM_LINEAR_API_KEY", "")
+        if not api_key:
+            raise RuntimeError("Linear is not configured.")
+        body = json.dumps({"query": query, "variables": variables or {}}).encode("utf-8")
+        request = Request(
+            LINEAR_API_URL,
+            data=body,
+            headers={
+                "Authorization": api_key,
+                "Content-Type": "application/json",
+                "User-Agent": "Reflectrum/0.1",
+            },
+            method="POST",
+        )
+        with urlopen(request, timeout=15) as response:
+            payload = response.read(MAX_LINEAR_BYTES + 1)
+        if len(payload) > MAX_LINEAR_BYTES:
+            raise ValueError("Linear response is too large.")
+        result = json.loads(payload)
+        if result.get("errors"):
+            raise ValueError("Linear returned a GraphQL error.")
+        return result.get("data", {})
+
+    def home_assistant_request(self, path):
+        base_url = os.environ.get("REFLECTRUM_HOME_ASSISTANT_URL", "").rstrip("/")
+        token = os.environ.get("REFLECTRUM_HOME_ASSISTANT_TOKEN", "")
+        if urlsplit(base_url).scheme not in ("http", "https") or not token:
+            raise RuntimeError("Home Assistant is not configured.")
+        request = Request(
+            f"{base_url}{path}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/json",
+                "User-Agent": "Reflectrum/0.1",
+            },
+        )
+        with urlopen(request, timeout=20) as response:
+            payload = response.read(MAX_HOME_ASSISTANT_BYTES + 1)
+        if len(payload) > MAX_HOME_ASSISTANT_BYTES:
+            raise ValueError("Home Assistant response is too large.")
+        return json.loads(payload)
+
+    @staticmethod
+    def normalize_home_state(state):
+        attributes = state.get("attributes") or {}
+        return {
+            "entityId": state.get("entity_id"),
+            "state": state.get("state"),
+            "lastChanged": state.get("last_changed"),
+            "name": attributes.get("friendly_name") or state.get("entity_id"),
+            "unit": attributes.get("unit_of_measurement"),
+            "deviceClass": attributes.get("device_class"),
+            "icon": attributes.get("icon"),
+        }
+
+    def serve_home_states(self):
+        with HOME_STATES_CACHE_LOCK:
+            cached = HOME_STATES_CACHE["states"]
+            age = time.monotonic() - HOME_STATES_CACHE["stored_at"]
+        if cached is not None and age < 15:
+            self.send_json(200, {"entities": cached, "stale": False})
+            return
+        try:
+            states = self.home_assistant_request("/api/states")
+            normalized = [
+                self.normalize_home_state(state)
+                for state in states
+                if HOME_ENTITY_PATTERN.match(state.get("entity_id", ""))
+            ]
+        except RuntimeError as error:
+            self.send_json_error(503, str(error))
+            return
+        except (HTTPError, URLError, TimeoutError, ValueError, TypeError, json.JSONDecodeError):
+            if cached is not None:
+                self.send_json(200, {"entities": cached, "stale": True})
+                return
+            self.send_json_error(502, "Home Assistant states could not be loaded.")
+            return
+        with HOME_STATES_CACHE_LOCK:
+            HOME_STATES_CACHE["states"] = normalized
+            HOME_STATES_CACHE["stored_at"] = time.monotonic()
+        self.send_json(200, {"entities": normalized, "stale": False})
+
+    def serve_home_history(self):
+        query = parse_qs(urlsplit(self.path).query)
+        entities = [value for value in query.get("entities", [""])[0].split(",") if value]
+        if not entities or len(entities) > 12 or any(not HOME_ENTITY_PATTERN.match(value) for value in entities):
+            self.send_json_error(400, "Provide one to twelve valid entity IDs.")
+            return
+        try:
+            hours = int(query.get("hours", ["24"])[0])
+        except ValueError:
+            hours = 0
+        if hours < 1 or hours > 168:
+            self.send_json_error(400, "History hours must be between 1 and 168.")
+            return
+        start = datetime.now(timezone.utc) - timedelta(hours=hours)
+        start_value = quote(start.isoformat(timespec="seconds"))
+        parameters = urlencode({
+            "filter_entity_id": ",".join(entities),
+            "minimal_response": "",
+            "no_attributes": "",
+        })
+        try:
+            history = self.home_assistant_request(f"/api/history/period/{start_value}?{parameters}")
+        except RuntimeError as error:
+            self.send_json_error(503, str(error))
+            return
+        except (HTTPError, URLError, TimeoutError, ValueError, TypeError, json.JSONDecodeError):
+            self.send_json_error(502, "Home Assistant history could not be loaded.")
+            return
+
+        series = []
+        for states in history:
+            points = []
+            entity_id = None
+            for state in states:
+                entity_id = state.get("entity_id") or entity_id
+                try:
+                    value = float(state.get("state"))
+                except (TypeError, ValueError):
+                    continue
+                points.append({"at": state.get("last_changed"), "value": value})
+            if entity_id and points:
+                series.append({"entityId": entity_id, "points": points[-300:]})
+        self.send_json(200, {"series": series, "hours": hours})
+
+    def serve_linear_issues(self):
+        query = """
+          query ReflectrumAssignedIssues($after: String) {
+            viewer {
+              assignedIssues(first: 50, after: $after) {
+                nodes {
+                  id identifier title priority dueDate updatedAt url
+                  state { id name type color }
+                  project { name }
+                }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+          }
+        """
+        with LINEAR_CACHE_LOCK:
+            cached = LINEAR_CACHE["issues"]
+            age = time.monotonic() - LINEAR_CACHE["stored_at"]
+        if cached is not None and age < LINEAR_CACHE_SECONDS:
+            self.send_json(200, {"issues": cached, "stale": False})
+            return
+
+        try:
+            nodes = []
+            after = None
+            for _page in range(4):
+                data = self.linear_graphql(query, {"after": after})
+                connection = data["viewer"]["assignedIssues"]
+                nodes.extend(connection["nodes"])
+                page_info = connection["pageInfo"]
+                if not page_info["hasNextPage"]:
+                    break
+                after = page_info["endCursor"]
+        except RuntimeError as error:
+            self.send_json_error(503, str(error))
+            return
+        except (HTTPError, URLError, TimeoutError, ValueError, KeyError, TypeError):
+            if cached is not None:
+                self.send_json(200, {"issues": cached, "stale": True})
+                return
+            self.send_json_error(502, "Assigned Linear issues could not be loaded.")
+            return
+        active = [
+            issue for issue in nodes
+            if issue.get("state", {}).get("type") not in ("completed", "canceled")
+        ]
+        active.sort(key=lambda issue: issue.get("updatedAt") or "", reverse=True)
+        active.sort(key=lambda issue: issue.get("dueDate") or "9999-12-31")
+        active.sort(key=lambda issue: issue.get("priority") if issue.get("priority") in range(1, 5) else 99)
+        with LINEAR_CACHE_LOCK:
+            LINEAR_CACHE["issues"] = active
+            LINEAR_CACHE["stored_at"] = time.monotonic()
+        self.send_json(200, {"issues": active, "stale": False})
+
+    def complete_linear_issue(self):
+        if not self.same_origin_request():
+            self.send_json_error(403, "Cross-origin Linear updates are not allowed.")
+            return
+        try:
+            body = self.read_json_request()
+        except ValueError as error:
+            self.send_json_error(400, str(error))
+            return
+        issue_id = body.get("id") if isinstance(body, dict) else None
+        if not isinstance(issue_id, str) or not issue_id or len(issue_id) > 64:
+            self.send_json_error(400, "A valid Linear issue ID is required.")
+            return
+
+        lookup = """
+          query ReflectrumCompletionState($id: String!) {
+            viewer { id }
+            issue(id: $id) {
+              id identifier title
+              assignee { id }
+              state { id name type color }
+              team { states { nodes { id name type } } }
+            }
+          }
+        """
+        mutation = """
+          mutation ReflectrumCompleteIssue($id: String!, $stateId: String!) {
+            issueUpdate(id: $id, input: { stateId: $stateId }) {
+              success
+              issue { id identifier title state { id name type color } }
+            }
+          }
+        """
+        try:
+            data = self.linear_graphql(lookup, {"id": issue_id})
+            issue = data.get("issue")
+            viewer = data.get("viewer")
+            assignee = (issue or {}).get("assignee") or {}
+            if not issue or not viewer or assignee.get("id") != viewer.get("id"):
+                self.send_json_error(403, "Only your assigned issues can be completed here.")
+                return
+            if issue.get("state", {}).get("type") == "completed":
+                self.send_json(200, {"issue": issue})
+                return
+            completed = next(
+                (state for state in issue["team"]["states"]["nodes"] if state["type"] == "completed"),
+                None,
+            )
+            if not completed:
+                raise ValueError("No completed workflow state is available.")
+            result = self.linear_graphql(
+                mutation,
+                {"id": issue["id"], "stateId": completed["id"]},
+            )["issueUpdate"]
+            if not result.get("success"):
+                raise ValueError("Linear did not complete the issue.")
+        except RuntimeError as error:
+            self.send_json_error(503, str(error))
+            return
+        except (HTTPError, URLError, TimeoutError, ValueError, KeyError, TypeError):
+            self.send_json_error(502, "The Linear issue could not be completed.")
+            return
+        with LINEAR_CACHE_LOCK:
+            LINEAR_CACHE["stored_at"] = 0
+        self.send_json(200, {"issue": result["issue"]})
+
+    def display_command(self, power=None):
+        wayland_command = shutil.which("wlr-randr")
+        if wayland_command:
+            output_name = os.environ.get("REFLECTRUM_DISPLAY_OUTPUT", "HDMI-A-1")
+            rotation = os.environ.get("REFLECTRUM_DISPLAY_ROTATION", "90")
+            allowed_rotations = {"normal", "90", "180", "270", "flipped", "flipped-90", "flipped-180", "flipped-270"}
+            if rotation not in allowed_rotations:
+                rotation = "90"
+            environment = os.environ.copy()
+            environment.setdefault("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+            environment.setdefault("WAYLAND_DISPLAY", "wayland-0")
+            if power is not None:
+                command = [wayland_command, "--output", output_name, "--off"]
+                if power == "on":
+                    command = [wayland_command, "--output", output_name, "--on", "--transform", rotation]
+                subprocess.run(
+                    command,
+                    capture_output=True,
+                    check=True,
+                    env=environment,
+                    text=True,
+                    timeout=3,
+                )
+            result = subprocess.run(
+                [wayland_command],
+                capture_output=True,
+                check=True,
+                env=environment,
+                text=True,
+                timeout=3,
+            )
+            lines = result.stdout.splitlines()
+            for index, line in enumerate(lines):
+                if line.startswith(f"{output_name} ") or line == output_name:
+                    block = lines[index + 1:]
+                    enabled = next((value for value in block if value.strip().startswith("Enabled:")), "")
+                    if enabled.strip() == "Enabled: yes":
+                        return "on"
+                    if enabled.strip() == "Enabled: no":
+                        return "off"
+                    break
+            raise ValueError("Configured Wayland output was not found.")
+
+        executable = shutil.which("vcgencmd")
+        if not executable:
+            raise FileNotFoundError("Display control is unavailable")
+        command = [executable, "display_power"]
+        if power is not None:
+            command.append("1" if power == "on" else "0")
+        result = subprocess.run(command, capture_output=True, check=True, text=True, timeout=3)
+        if "display_power=1" in result.stdout:
+            return "on"
+        if "display_power=0" in result.stdout:
+            return "off"
+        return "unknown"
+
+    def serve_display_status(self):
+        try:
+            with DISPLAY_POWER_LOCK:
+                power = self.display_command()
+        except (FileNotFoundError, subprocess.SubprocessError, ValueError) as error:
+            self.log_error("Display status command failed: %r", error)
+            self.send_json(200, {"power": "on", "supported": False})
+            return
+        self.send_json(200, {"power": power, "supported": True})
+
+    def set_display_power(self):
+        if not self.same_origin_request():
+            self.send_json_error(403, "Cross-origin display control is not allowed.")
+            return
+
+        try:
+            request = self.read_json_request()
+        except ValueError as error:
+            self.send_json_error(400, str(error))
+            return
+        power = request.get("power") if isinstance(request, dict) else None
+        if power not in ("on", "off"):
+            self.send_json_error(400, "Power must be on or off.")
+            return
+
+        try:
+            with DISPLAY_POWER_LOCK:
+                actual = self.display_command(power)
+        except FileNotFoundError as error:
+            self.log_error("Display power command is unavailable: %r", error)
+            self.send_json_error(501, "Hardware display control is unavailable.")
+            return
+        except (subprocess.SubprocessError, ValueError) as error:
+            self.log_error("Display power command failed: %r", error)
+            self.send_json_error(502, "Display power command failed.")
+            return
+        self.send_json(200, {"power": actual, "supported": True})
+
+    def run_system_power_command(self, command):
+        executable = shutil.which("systemctl")
+        if not executable:
+            self.log_error("System power command is unavailable.")
+            return
+        try:
+            subprocess.run(
+                [executable, "--no-wall", command],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except subprocess.SubprocessError as error:
+            self.log_error("System power command failed: %r", error)
+
+    def set_system_power(self):
+        if not self.same_origin_request():
+            self.send_json_error(403, "Cross-origin system power control is not allowed.")
+            return
+        try:
+            request = self.read_json_request()
+        except ValueError as error:
+            self.send_json_error(400, str(error))
+            return
+        action = request.get("action") if isinstance(request, dict) else None
+        command = SYSTEM_POWER_COMMANDS.get(action)
+        if not command:
+            self.send_json_error(400, "Action must be reboot or shutdown.")
+            return
+
+        self.send_json(202, {"accepted": True, "action": action})
+        timer = threading.Timer(1, self.run_system_power_command, args=(command,))
+        timer.daemon = True
+        timer.start()
 
     def serve_calendar(self):
         feed_url = os.environ.get("REFLECTRUM_CALENDAR_ICS_URL", "")

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "pi:deploy": "./scripts/pi-deploy",
     "pi:refresh": "./scripts/pi-refresh",
     "pi:screenshare": "./scripts/pi-screenshare",
-    "check": "python3 -c \"import ast, pathlib; ast.parse(pathlib.Path('deploy/reflectrum_server.py').read_text())\" && npm test && vite build",
+    "pi:screenshare:setup": "./scripts/pi-screenshare-setup",
+    "check": "python3 -m unittest discover -s test -p 'test_*.py' && npm test && vite build",
     "test": "node --test"
   },
   "repository": {

--- a/scripts/pi-deploy
+++ b/scripts/pi-deploy
@@ -3,20 +3,41 @@ set -eu
 
 script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 repo_root=$(dirname -- "$script_dir")
-pi_host=${REFLECTRUM_PI_HOST:-adsb}
+pi_host=${REFLECTRUM_PI_HOST:-adsb.local}
 pi_staging=/home/pi/reflectrum-dist
+runtime_staging=/home/pi/reflectrum-runtime
 
 cd "$repo_root"
 npm run check
 
 rsync -az --delete dist/ "$pi_host:$pi_staging/"
+ssh "$pi_host" "mkdir -p $runtime_staging"
+rsync -az --delete \
+  deploy/reflectrum_server.py \
+  deploy/reflectrum-web.service \
+  deploy/reflectrum-night-shift \
+  deploy/reflectrum-night-shift.service \
+  deploy/reflectrum-night-shift.desktop \
+  deploy/50-reflectrum-power.rules \
+  deploy/reflectrum-solaar-rules.yaml \
+  "$pi_host:$runtime_staging/"
 
 # Install only generated files. The Pi's deployment-local
 # reflectrum-config.js and private calendar environment stay untouched.
 ssh "$pi_host" "sudo install -d -o pi -g pi -m 0755 /opt/reflectrum/assets"
 ssh "$pi_host" "sudo cp -a $pi_staging/assets/. /opt/reflectrum/assets/"
 ssh "$pi_host" "sudo cp $pi_staging/index.html /opt/reflectrum/index.html"
+ssh "$pi_host" "sudo install -o root -g root -m 0755 $runtime_staging/reflectrum_server.py /usr/local/lib/reflectrum/reflectrum_server.py"
+ssh "$pi_host" "sudo install -o root -g root -m 0644 $runtime_staging/reflectrum-web.service /etc/systemd/system/reflectrum-web.service"
+ssh "$pi_host" "sudo install -o root -g root -m 0755 $runtime_staging/reflectrum-night-shift /usr/local/bin/reflectrum-night-shift"
+ssh "$pi_host" "sudo install -o root -g root -m 0644 $runtime_staging/reflectrum-night-shift.service /etc/systemd/user/reflectrum-night-shift.service"
+ssh "$pi_host" "sudo install -o root -g root -m 0644 $runtime_staging/reflectrum-night-shift.desktop /etc/xdg/autostart/reflectrum-night-shift.desktop"
+ssh "$pi_host" "sudo install -o root -g root -m 0644 $runtime_staging/50-reflectrum-power.rules /etc/polkit-1/rules.d/50-reflectrum-power.rules"
+ssh "$pi_host" "sudo install -o pi -g pi -m 0644 $runtime_staging/reflectrum-solaar-rules.yaml /home/pi/.config/solaar/rules.yaml"
+ssh "$pi_host" "sudo systemctl daemon-reload && sudo systemctl --global enable reflectrum-night-shift.service && sudo systemctl restart reflectrum-web.service"
+ssh "$pi_host" "systemctl --user daemon-reload && systemctl --user enable --now reflectrum-night-shift.service"
 
 "$script_dir/pi-refresh"
 
 printf '%s\n' 'Reflectrum built, deployed, and refreshed.'
+printf '%s\n' 'Reboot once after changing Dialpad rules so the running Solaar session reloads them.'

--- a/scripts/pi-refresh
+++ b/scripts/pi-refresh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-pi_host=${REFLECTRUM_PI_HOST:-adsb}
+pi_host=${REFLECTRUM_PI_HOST:-adsb.local}
 
 if ssh "$pi_host" "systemctl --user --machine=pi@ --quiet is-active reflectrum-kiosk.service"; then
   kiosk_unit=reflectrum-kiosk.service

--- a/scripts/pi-screenshare
+++ b/scripts/pi-screenshare
@@ -1,14 +1,29 @@
 #!/bin/sh
 set -eu
 
-pi_host=${REFLECTRUM_PI_HOST:-adsb}
+pi_host=${REFLECTRUM_PI_HOST:-adsb.local}
 local_port=${REFLECTRUM_VNC_LOCAL_PORT:-5900}
 viewer=${REFLECTRUM_VNC_VIEWER:-/Applications/TigerVNC.app/Contents/MacOS/vncviewer}
+keychain_service=${REFLECTRUM_VNC_KEYCHAIN_SERVICE:-com.reflectrum.screenshare}
+VNC_USERNAME=${VNC_USERNAME:-reflectrum}
 
 if [ ! -x "$viewer" ]; then
   printf '%s\n' 'TigerVNC is not installed in /Applications.' >&2
   exit 1
 fi
+
+if [ -z "${VNC_PASSWORD:-}" ]; then
+  if ! VNC_PASSWORD=$(security find-generic-password \
+    -a "$VNC_USERNAME" \
+    -s "$keychain_service" \
+    -w 2>/dev/null); then
+    printf '%s\n' \
+      "No Reflectrum screen-share password was found in macOS Keychain." \
+      "Run the local credential setup before starting screen sharing." >&2
+    exit 1
+  fi
+fi
+export VNC_USERNAME VNC_PASSWORD
 
 if ! nc -z 127.0.0.1 "$local_port" >/dev/null 2>&1; then
   ssh -f -N -T \

--- a/scripts/pi-screenshare-setup
+++ b/scripts/pi-screenshare-setup
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -eu
+
+pi_host=${REFLECTRUM_PI_HOST:-adsb.local}
+keychain_service=${REFLECTRUM_VNC_KEYCHAIN_SERVICE:-com.reflectrum.screenshare}
+vnc_username=${REFLECTRUM_VNC_USERNAME:-reflectrum}
+
+old_password=
+had_old_password=false
+if old_password=$(security find-generic-password \
+  -a "$vnc_username" \
+  -s "$keychain_service" \
+  -w 2>/dev/null); then
+  had_old_password=true
+fi
+
+new_password=$(openssl rand -hex 24)
+trap 'unset old_password new_password' EXIT HUP INT TERM
+
+security add-generic-password \
+  -a "$vnc_username" \
+  -s "$keychain_service" \
+  -l 'Reflectrum Pi screen share' \
+  -w "$new_password" \
+  -U >/dev/null
+
+if ! printf '%s\n' "$new_password" | ssh -o BatchMode=yes "$pi_host" '
+  set -eu
+  IFS= read -r new_password
+  config=/etc/wayvnc/config
+  rollback=/etc/wayvnc/config.before-keychain-setup
+
+  sudo grep -q "^enable_auth=" "$config"
+  sudo grep -q "^username=" "$config"
+  sudo grep -q "^password=" "$config"
+  sudo cp --preserve=mode,ownership "$config" "$rollback"
+  sudo sed -i \
+    -e "s/^enable_auth=.*/enable_auth=true/" \
+    -e "s/^username=.*/username=reflectrum/" \
+    -e "s/^password=.*/password=$new_password/" \
+    "$config"
+  sudo chown root:vnc "$config" "$rollback"
+  sudo chmod 640 "$config" "$rollback"
+
+  if ! sudo systemctl restart wayvnc.service || \
+     ! systemctl is-active --quiet wayvnc.service; then
+    sudo cp --preserve=mode,ownership "$rollback" "$config"
+    sudo systemctl restart wayvnc.service
+    exit 1
+  fi
+
+  test "$(sudo awk -F= '\''$1 == "address" { print $2 }'\'' "$config")" = 127.0.0.1
+'; then
+  if [ "$had_old_password" = true ]; then
+    security add-generic-password \
+      -a "$vnc_username" \
+      -s "$keychain_service" \
+      -l 'Reflectrum Pi screen share' \
+      -w "$old_password" \
+      -U >/dev/null
+  else
+    security delete-generic-password \
+      -a "$vnc_username" \
+      -s "$keychain_service" >/dev/null 2>&1 || true
+  fi
+  printf '%s\n' 'Screen-share setup failed; the local Keychain change was rolled back.' >&2
+  exit 1
+fi
+
+printf '%s\n' \
+  'Reflectrum screen-share authentication is synchronized with macOS Keychain.'

--- a/test/test_reflectrum_server.py
+++ b/test/test_reflectrum_server.py
@@ -1,0 +1,97 @@
+import io
+import json
+import pathlib
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "deploy"))
+
+from reflectrum_server import ReflectrumHandler  # noqa: E402
+
+
+class ReflectrumServerTests(unittest.TestCase):
+    def make_handler(self, headers=None, body=b""):
+        handler = ReflectrumHandler.__new__(ReflectrumHandler)
+        handler.headers = headers or {}
+        handler.rfile = io.BytesIO(body)
+        return handler
+
+    def test_display_command_uses_wayland_output_and_restores_rotation(self):
+        handler = self.make_handler()
+        results = [
+            SimpleNamespace(stdout=""),
+            SimpleNamespace(stdout='HDMI-A-1 "Display"\n  Enabled: no\n'),
+        ]
+        with patch("reflectrum_server.shutil.which", return_value="/usr/bin/wlr-randr"), patch(
+            "reflectrum_server.subprocess.run", side_effect=results
+        ) as run:
+            self.assertEqual(handler.display_command("off"), "off")
+        self.assertEqual(run.call_args_list[0].args[0], [
+            "/usr/bin/wlr-randr", "--output", "HDMI-A-1", "--off"
+        ])
+        self.assertEqual(run.call_args_list[1].args[0], ["/usr/bin/wlr-randr"])
+
+    def test_json_body_is_bounded_and_parsed(self):
+        body = json.dumps({"power": "on"}).encode()
+        handler = self.make_handler({"Content-Length": str(len(body))}, body)
+        self.assertEqual(handler.read_json_request(), {"power": "on"})
+
+        oversized = self.make_handler({"Content-Length": "999999"})
+        with self.assertRaisesRegex(ValueError, "request size"):
+            oversized.read_json_request()
+
+    def test_cross_origin_mutations_are_rejected(self):
+        allowed = self.make_handler({"Origin": "http://127.0.0.1:3000", "Host": "127.0.0.1:3000"})
+        rejected = self.make_handler({"Origin": "https://attacker.example", "Host": "127.0.0.1:3000"})
+        self.assertTrue(allowed.same_origin_request())
+        self.assertFalse(rejected.same_origin_request())
+
+    def test_system_power_is_allowlisted_and_deferred(self):
+        body = json.dumps({"action": "reboot"}).encode()
+        handler = self.make_handler(
+            {
+                "Content-Length": str(len(body)),
+                "Origin": "http://127.0.0.1:3000",
+                "Host": "127.0.0.1:3000",
+            },
+            body,
+        )
+        handler.send_json = Mock()
+        timer = Mock()
+        with patch("reflectrum_server.threading.Timer", return_value=timer) as timer_class:
+            handler.set_system_power()
+        handler.send_json.assert_called_once_with(202, {"accepted": True, "action": "reboot"})
+        timer_class.assert_called_once_with(1, handler.run_system_power_command, args=("reboot",))
+        self.assertTrue(timer.daemon)
+        timer.start.assert_called_once_with()
+
+        invalid_body = json.dumps({"action": "hibernate"}).encode()
+        invalid = self.make_handler(
+            {"Content-Length": str(len(invalid_body))},
+            invalid_body,
+        )
+        invalid.send_json_error = Mock()
+        invalid.set_system_power()
+        invalid.send_json_error.assert_called_once_with(400, "Action must be reboot or shutdown.")
+
+    def test_home_state_exposes_only_dashboard_fields(self):
+        normalized = ReflectrumHandler.normalize_home_state({
+            "entity_id": "lock.front_door",
+            "state": "locked",
+            "last_changed": "2026-08-16T20:00:00Z",
+            "context": {"secret": "not returned"},
+            "attributes": {
+                "friendly_name": "Front Door",
+                "device_class": "lock",
+                "access_token": "not returned",
+            },
+        })
+        self.assertEqual(normalized["name"], "Front Door")
+        self.assertNotIn("context", normalized)
+        self.assertNotIn("access_token", normalized)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- move Night Shift to a compositor-level wlsunset service with desktop-session startup
- extend the loopback Pi runtime for display, system, Linear, and Home Assistant integrations
- make deploy, refresh, and screen-share tooling use adsb.local and macOS Keychain-backed VNC credentials

## Stack
1. **This PR**
2. Display and Settings controls
3. Fish-tank screensaver
4. Linear dashboard
5. Home Assistant dashboard

## Testing
- npm run check
- verified SSH resolution and connection through adsb.local