### PR TITLE
Add display and system controls

### DIFF
--- a/src/components/DisplayPower.css
+++ b/src/components/DisplayPower.css
@@ -1,0 +1,30 @@
+.display-power-curtain {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  pointer-events: none;
+  background: #000;
+  opacity: 0;
+  transition: opacity 220ms ease-out;
+}
+
+.display-power-curtain.is-dimming,
+.display-power-curtain.is-off,
+.display-power-curtain.is-checking {
+  opacity: 1;
+}
+
+.display-power-curtain.is-checking {
+  transition: none;
+}
+
+.display-power-curtain.is-waking {
+  opacity: 0;
+  transition-duration: 180ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .display-power-curtain {
+    transition-duration: 80ms;
+  }
+}

--- a/src/components/DisplayPower.jsx
+++ b/src/components/DisplayPower.jsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { MirrorEvents, setNavigationInputBlocked } from '../helpers/events.jsx';
+import { getDisplayPower, setDisplayPower } from '../providers/displayPower.js';
+import './DisplayPower.css';
+
+const wait = (milliseconds) => new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+const DISPLAY_PHASE_KEY = 'reflectrum.displayPower.phase';
+
+const initialPhase = () => (
+  ['off', 'waking'].includes(sessionStorage.getItem(DISPLAY_PHASE_KEY)) ? 'off' : 'checking'
+);
+
+export default function DisplayPower() {
+  const [phase, setPhase] = useState(initialPhase);
+  const phaseRef = useRef(initialPhase());
+  const busyRef = useRef(false);
+
+  const changePhase = (nextPhase) => {
+    phaseRef.current = nextPhase;
+    setPhase(nextPhase);
+  };
+
+  useEffect(() => {
+    const controller = new AbortController();
+    if (phaseRef.current === 'off') setNavigationInputBlocked(true);
+    getDisplayPower({ signal: controller.signal })
+      .then(({ power }) => {
+        if (power === 'off') {
+          sessionStorage.setItem(DISPLAY_PHASE_KEY, 'off');
+          setNavigationInputBlocked(true);
+          changePhase('off');
+        } else if (sessionStorage.getItem(DISPLAY_PHASE_KEY) === 'waking') {
+          setNavigationInputBlocked(true);
+          changePhase('waking');
+          wait(200).then(() => {
+            sessionStorage.removeItem(DISPLAY_PHASE_KEY);
+            setNavigationInputBlocked(false);
+            changePhase('on');
+          });
+        } else if (sessionStorage.getItem(DISPLAY_PHASE_KEY) !== 'off') {
+          sessionStorage.removeItem(DISPLAY_PHASE_KEY);
+          changePhase('on');
+        }
+      })
+      .catch(() => {
+        // Vite development does not provide the Pi-only endpoint.
+        if (phaseRef.current === 'checking') changePhase('on');
+      });
+
+    const listener = MirrorEvents.addListener('DISPLAY_TOGGLE', async () => {
+      if (busyRef.current) return;
+      busyRef.current = true;
+
+      if (phaseRef.current === 'on') {
+        sessionStorage.setItem(DISPLAY_PHASE_KEY, 'off');
+        setNavigationInputBlocked(true);
+        changePhase('dimming');
+        await wait(240);
+        try {
+          await setDisplayPower('off');
+          changePhase('off');
+        } catch (error) {
+          console.warn('Unable to power off the display:', error.message);
+          // Stay black and let the dedicated toggle recover; revealing the UI
+          // after an uncertain hardware command can cause a bright flash.
+          changePhase('off');
+        }
+      } else {
+        sessionStorage.setItem(DISPLAY_PHASE_KEY, 'waking');
+        try {
+          await setDisplayPower('on');
+          await wait(120);
+        } catch (error) {
+          console.warn('Unable to power on the display:', error.message);
+        } finally {
+          changePhase('waking');
+          await wait(200);
+          sessionStorage.removeItem(DISPLAY_PHASE_KEY);
+          setNavigationInputBlocked(false);
+          changePhase('on');
+        }
+      }
+
+      busyRef.current = false;
+    });
+
+    return () => {
+      controller.abort();
+      listener.remove();
+      setNavigationInputBlocked(false);
+    };
+  }, []);
+
+  return <div className={`display-power-curtain is-${phase}`} aria-hidden="true" />;
+}

--- a/src/components/MainMenu.jsx
+++ b/src/components/MainMenu.jsx
@@ -25,6 +25,11 @@ export const mainMenu = {
       name: "quotes",
       color: "#787AFF",
       key: "QUOTES"
+    },
+    {
+      name: "settings",
+      color: "#FF9F0A",
+      key: "SETTINGS"
     }
   ]
 }

--- a/src/components/ViewStack.css
+++ b/src/components/ViewStack.css
@@ -19,7 +19,7 @@
 ::view-transition-group(reflectrum-page) {
   z-index: 1;
   overflow: hidden;
-  animation-duration: 480ms;
+  animation-duration: 320ms;
   animation-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
 }
 
@@ -46,13 +46,13 @@ html[data-page-transition-direction='push']::view-transition-old(reflectrum-page
 html[data-page-transition-direction='push']::view-transition-new(reflectrum-page) {
   z-index: 2;
   animation-name: reflectrum-push-new;
-  box-shadow: -24px 0 56px rgb(0 0 0 / 55%);
+  box-shadow: -14px 0 34px rgb(0 0 0 / 42%);
 }
 
 html[data-page-transition-direction='pop']::view-transition-old(reflectrum-page) {
   z-index: 2;
   animation-name: reflectrum-pop-old;
-  box-shadow: -24px 0 56px rgb(0 0 0 / 55%);
+  box-shadow: -14px 0 34px rgb(0 0 0 / 42%);
 }
 
 html[data-page-transition-direction='pop']::view-transition-new(reflectrum-page) {
@@ -61,12 +61,10 @@ html[data-page-transition-direction='pop']::view-transition-new(reflectrum-page)
 
 @keyframes reflectrum-push-old {
   from {
-    transform: translateX(0) scale(1);
-    filter: brightness(1);
+    transform: translateX(0);
   }
   to {
-    transform: translateX(-28%) scale(0.96);
-    filter: brightness(0.72);
+    transform: translateX(-18%);
   }
 }
 
@@ -82,12 +80,10 @@ html[data-page-transition-direction='pop']::view-transition-new(reflectrum-page)
 
 @keyframes reflectrum-pop-new {
   from {
-    transform: translateX(-28%) scale(0.96);
-    filter: brightness(0.72);
+    transform: translateX(-18%);
   }
   to {
-    transform: translateX(0) scale(1);
-    filter: brightness(1);
+    transform: translateX(0);
   }
 }
 

--- a/src/components/ViewStack.jsx
+++ b/src/components/ViewStack.jsx
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import {pages} from '../helpers/pages.jsx';
 
 import { StandbyContainer } from './Standby.jsx';
+import DisplayPower from './DisplayPower.jsx';
 import { connect } from 'react-redux';
 import './ViewStack.css';
 class ViewStack extends Component {
@@ -17,6 +18,7 @@ class ViewStack extends Component {
           {pages[activePageName]}
         </div>
         <StandbyContainer />
+        <DisplayPower />
       </div>
     )
   }

--- a/src/components/menu/Menu.css
+++ b/src/components/menu/Menu.css
@@ -30,20 +30,23 @@ body > div {
 
 .menu-list {
   position: relative;
+  --menu-item-height: min(200px, calc((100vh - 260px) / var(--menu-item-count)));
 }
 
 .menu-list-select-item {
   background-color: white;
   opacity: 0.4;
   position: absolute;
-  height: 200px;
+  height: var(--menu-item-height);
   width: 100%;
   top: 0;
-  transition: top 0.5s ease;
+  transform: translateY(calc(var(--selected-item) * var(--menu-item-height)));
+  transition: transform 180ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  will-change: transform;
 }
 
 .menu-list-item {
-  height: 200px;
+  height: var(--menu-item-height);
   color: white;
   opacity: 1;
   display: flex;
@@ -53,7 +56,7 @@ body > div {
   font-size: 80px;
   color: white;
   text-decoration: none;
-  line-height: 200px;
+  line-height: var(--menu-item-height);
   margin: auto;
   flex: 75%;
 }

--- a/src/components/menu/MenuList.jsx
+++ b/src/components/menu/MenuList.jsx
@@ -8,7 +8,7 @@ class MenuList extends Component {
   render() {
     const props = this.props;
     return (
-        <div className="menu-list">
+        <div className="menu-list" style={{ '--menu-item-count': props.items.length }}>
           <MenuListSelectedItem selectedItem={props.selectedItem} className="menu-list-select-item" />
           <div>
           {

--- a/src/components/menu/MenuListSelectedItem.jsx
+++ b/src/components/menu/MenuListSelectedItem.jsx
@@ -3,10 +3,8 @@ import React, { Component } from 'react';
 class MenuListSelectedItem extends Component {
   render() {
     const props = this.props;
-    const top = props.selectedItem * 200 + 'px'
-
     return (
-      <div style={{top: top}} className="menu-list-select-item"></div>
+      <div style={{ '--selected-item': props.selectedItem }} className="menu-list-select-item"></div>
     )
   }
 }

--- a/src/components/settings/Settings.css
+++ b/src/components/settings/Settings.css
@@ -1,0 +1,127 @@
+.settings-page {
+  min-height: 100%;
+  padding: 54px 46px 42px;
+  background: #08080a;
+  color: #f5f5f7;
+  letter-spacing: normal;
+}
+
+.settings-page__header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  margin-bottom: 76px;
+}
+
+.settings-page__eyebrow,
+.settings-confirm__eyebrow {
+  color: #8e8e93;
+  font-size: 18px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+.settings-page h1 {
+  margin: 8px 0 0;
+  font-size: 58px;
+  font-weight: 500;
+}
+
+.settings-page__device {
+  padding-bottom: 8px;
+  color: #8e8e93;
+  font-size: 21px;
+}
+
+.settings-page__actions {
+  display: grid;
+  gap: 22px;
+}
+
+.settings-action {
+  display: grid;
+  grid-template-columns: 10px 1fr;
+  gap: 26px;
+  min-height: 190px;
+  padding: 36px 34px;
+  border: 1px solid #2b2b30;
+  border-radius: 24px;
+  background: #141417;
+}
+
+.settings-action.is-selected {
+  border-color: var(--settings-accent);
+  background: #1d1d21;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--settings-accent) 30%, transparent);
+}
+
+.settings-action__indicator {
+  border-radius: 999px;
+  background: var(--settings-accent);
+}
+
+.settings-action h2 {
+  margin: 2px 0 18px;
+  font-size: 32px;
+  font-weight: 500;
+}
+
+.settings-action p {
+  margin: 0;
+  color: #9b9ba1;
+  font-size: 21px;
+  line-height: 1.45;
+}
+
+.settings-page__hint {
+  margin-top: 48px;
+  color: #717178;
+  font-size: 18px;
+  text-align: center;
+}
+
+.settings-page__error {
+  margin: -46px 0 26px;
+  padding: 14px 18px;
+  border-radius: 12px;
+  background: #321719;
+  color: #ff8b91;
+  font-size: 19px;
+  text-align: center;
+}
+
+.settings-confirm {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: grid;
+  place-items: center;
+  padding: 54px;
+  background: rgb(0 0 0 / 88%);
+}
+
+.settings-confirm__card {
+  width: 100%;
+  padding: 52px 44px;
+  border: 2px solid var(--settings-accent);
+  border-radius: 28px;
+  background: #19191d;
+  text-align: center;
+}
+
+.settings-confirm__eyebrow {
+  color: var(--settings-accent);
+}
+
+.settings-confirm h2 {
+  margin: 26px 0 32px;
+  font-size: 39px;
+  font-weight: 500;
+}
+
+.settings-confirm p {
+  margin: 0;
+  color: #b2b2b7;
+  font-size: 23px;
+  line-height: 1.55;
+}

--- a/src/components/settings/Settings.jsx
+++ b/src/components/settings/Settings.jsx
@@ -1,0 +1,121 @@
+import React, { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
+import { MirrorEvents } from '../../helpers/events.jsx';
+import { requestSystemPower } from '../../providers/systemPower.js';
+import './Settings.css';
+
+const actions = [
+  {
+    action: 'reboot',
+    title: 'Restart Raspberry Pi',
+    detail: 'Restart the mirror, ADS-B feeder, and Reflectrum.',
+    accent: '#ff9f0a',
+  },
+  {
+    action: 'shutdown',
+    title: 'Shut Down Raspberry Pi',
+    detail: 'Safely stop the Pi before disconnecting power.',
+    accent: '#ff453a',
+  },
+];
+
+function Settings({ onBack, onMainMenu }) {
+  const [selected, setSelected] = useState(0);
+  const [confirming, setConfirming] = useState(null);
+  const [status, setStatus] = useState('ready');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const listeners = [
+      MirrorEvents.addListener('UP_CLICK', () => {
+        if (!confirming && status === 'ready') setSelected((current) => Math.max(0, current - 1));
+      }),
+      MirrorEvents.addListener('DOWN_CLICK', () => {
+        if (!confirming && status === 'ready') setSelected((current) => Math.min(actions.length - 1, current + 1));
+      }),
+      MirrorEvents.addListener('PRIMARY_CLICK', async () => {
+        if (status !== 'ready') return;
+        const selectedAction = actions[selected];
+        if (!confirming) {
+          setError('');
+          setConfirming(selectedAction.action);
+          return;
+        }
+        setStatus('sending');
+        try {
+          await requestSystemPower(confirming);
+          setStatus('accepted');
+        } catch (requestError) {
+          setError(requestError.message);
+          setConfirming(null);
+          setStatus('ready');
+        }
+      }),
+      MirrorEvents.addListener('SECONDARY_CLICK', () => {
+        if (confirming && status === 'ready') setConfirming(null);
+        else if (status === 'ready') onBack();
+      }),
+      MirrorEvents.addListener('SECONDARY_HOLD', () => {
+        if (status === 'ready') onMainMenu();
+      }),
+    ];
+    return () => listeners.forEach((listener) => listener.remove());
+  }, [confirming, onBack, onMainMenu, selected, status]);
+
+  const confirmingAction = actions.find((item) => item.action === confirming);
+
+  return (
+    <main className="settings-page">
+      <header className="settings-page__header">
+        <div>
+          <div className="settings-page__eyebrow">Reflectrum</div>
+          <h1>Settings</h1>
+        </div>
+        <div className="settings-page__device">Raspberry Pi</div>
+      </header>
+
+      {error && <div className="settings-page__error">{error}</div>}
+
+      <section className="settings-page__actions">
+        {actions.map((item, index) => (
+          <article
+            className={`settings-action${selected === index ? ' is-selected' : ''}`}
+            style={{ '--settings-accent': item.accent }}
+            key={item.action}
+          >
+            <div className="settings-action__indicator" />
+            <div>
+              <h2>{item.title}</h2>
+              <p>{item.detail}</p>
+            </div>
+          </article>
+        ))}
+      </section>
+
+      <footer className="settings-page__hint">Select an action · Back to return</footer>
+
+      {confirmingAction && (
+        <div className="settings-confirm">
+          <div className="settings-confirm__card" style={{ '--settings-accent': confirmingAction.accent }}>
+            <div className="settings-confirm__eyebrow">Confirm system action</div>
+            <h2>{status === 'accepted' ? 'Command accepted' : confirmingAction.title}</h2>
+            <p>
+              {status === 'ready' && 'Press select again to continue. Press back to cancel.'}
+              {status === 'sending' && 'Sending the command to the Raspberry Pi…'}
+              {status === 'accepted' && (confirming === 'reboot'
+                ? 'Reflectrum will return after the Pi restarts.'
+                : 'Wait for the display to turn off before disconnecting power.')}
+            </p>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}
+
+const mapDispatchToProps = (dispatch) => ({
+  onBack: () => dispatch({ type: 'BACK' }),
+  onMainMenu: () => dispatch({ type: 'OPEN_MAIN_MENU' }),
+});
+
+export default connect(null, mapDispatchToProps)(Settings);

--- a/src/helpers/events.jsx
+++ b/src/helpers/events.jsx
@@ -16,6 +16,17 @@ const wheelConfig = {
 const wheelCooldownMs = inputConfig.wheelCooldownMs ?? 90;
 const pressState = { primary: false, secondary: false };
 let lastWheelActionAt = 0;
+let navigationInputBlocked = false;
+
+export const setNavigationInputBlocked = (blocked) => {
+  navigationInputBlocked = Boolean(blocked);
+};
+
+const emitAction = (action) => {
+  if (action === 'DISPLAY_TOGGLE' || !navigationInputBlocked) {
+    MirrorEvents.emit(action);
+  }
+};
 
 const diagnostic = (details) => MirrorEvents.emit('INPUT_DIAGNOSTIC', {
   timestamp: new Date().toISOString(),
@@ -34,14 +45,14 @@ const beginButtonPress = (name, event) => {
     pressState[name] = 'click';
   } else if (event.repeat && pressState[name] === 'click') {
     pressState[name] = 'hold';
-    MirrorEvents.emit(name === 'primary' ? 'PRIMARY_HOLD' : 'SECONDARY_HOLD');
+    emitAction(name === 'primary' ? 'PRIMARY_HOLD' : 'SECONDARY_HOLD');
   }
 };
 
 const finishButtonPress = (name, event) => {
   event.preventDefault();
   if (pressState[name] === 'click') {
-    MirrorEvents.emit(name === 'primary' ? 'PRIMARY_CLICK' : 'SECONDARY_CLICK');
+    emitAction(name === 'primary' ? 'PRIMARY_CLICK' : 'SECONDARY_CLICK');
   }
   pressState[name] = false;
 };
@@ -57,7 +68,7 @@ const registerInputListeners = () => {
       beginButtonPress(name, event);
     } else {
       event.preventDefault();
-      if (!event.repeat) MirrorEvents.emit(action);
+      if (!event.repeat) emitAction(action);
     }
   });
 
@@ -78,7 +89,7 @@ const registerInputListeners = () => {
     event.preventDefault();
     if (!throttled) {
       lastWheelActionAt = now;
-      MirrorEvents.emit(action);
+      emitAction(action);
     }
   }, { passive: false });
 
@@ -89,7 +100,7 @@ const registerInputListeners = () => {
   document.addEventListener('mouseup', (event) => {
     const action = resolveMouseAction(event.button);
     diagnostic({ source: 'mouse', type: 'mouseup', button: event.button, action });
-    if (action) MirrorEvents.emit(action);
+    if (action) emitAction(action);
   });
 
   document.addEventListener('contextmenu', (event) => event.preventDefault());

--- a/src/helpers/icons.jsx
+++ b/src/helpers/icons.jsx
@@ -1,6 +1,10 @@
 'use strict';
 
 const store = {
+  'home': `<svg width="80px" height="80px" viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M7 38 40 9l33 29-6 7-5-4v30H46V50H34v21H18V41l-5 4-6-7Z"/></svg>`,
+  'linear': `<svg width="80px" height="80px" viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M8 46a34 34 0 0 0 26 26L8 46Zm0-12 38 38c4-1 8-2 11-4L12 23c-2 3-3 7-4 11Zm9-19 48 48c3-3 5-6 6-10L27 9c-4 1-7 3-10 6Zm22-9 35 35v-1A34 34 0 0 0 40 6h-1Z"/></svg>`,
+  'aquarium': `<svg width="80px" height="80px" viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M51 24c-10-6-24-1-31 8-5-5-11-8-18-8 3 6 3 26 0 32 7 0 13-3 18-8 7 9 21 14 31 8 8-5 13-13 15-16-2-3-7-11-15-16Zm4 15a4 4 0 1 1 0-8 4 4 0 0 1 0 8Z"/><path fill="currentColor" opacity=".7" d="M67 15a5 5 0 1 0 0-10 5 5 0 0 0 0 10Zm5 16a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z"/></svg>`,
+  'settings': `<svg width="80px" height="80px" viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="m68 44 7 5-8 14-8-3-7 4-1 9H35l-2-9-7-4-8 3-8-14 7-5v-8l-7-5 8-14 8 3 7-4 2-9h16l1 9 7 4 8-3 8 14-7 5v8ZM43 54a14 14 0 1 0 0-28 14 14 0 0 0 0 28Z"/></svg>`,
   'close_quotes': `<svg width="140px" height="115px" viewBox="0 0 140 115" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
                       <!-- Generator: Sketch 3.4.4 (17249) - http://www.bohemiancoding.com/sketch -->
                       <title>Closing quotes</title>

--- a/src/helpers/inputMapping.js
+++ b/src/helpers/inputMapping.js
@@ -1,4 +1,5 @@
 export const DEFAULT_KEY_MAP = Object.freeze({
+  F13: 'DISPLAY_TOGGLE',
   ArrowUp: 'UP_CLICK',
   PageUp: 'UP_CLICK',
   MediaTrackPrevious: 'UP_CLICK',

--- a/src/helpers/pages.jsx
+++ b/src/helpers/pages.jsx
@@ -9,6 +9,7 @@ import { QuotesPage } from '../components/quotes/Quotes.jsx'
 import { LockscreenScreensaver } from '../components/LockscreenScreensaver'
 import { WeatherContainer } from '../components/weather/Weather.jsx'
 import OpeningPage from '../components/goodmorning/Opening.jsx'
+import Settings from '../components/settings/Settings.jsx';
 
 export const pages = {
   "MAIN_MENU": <MainMenu />,
@@ -20,5 +21,6 @@ export const pages = {
   "QUOTES": <QuotesPage />,
   "LOCKSCREEN": <LockscreenScreensaver />,
   "WEATHER": <WeatherContainer />,
-  "OPENING": <OpeningPage />
+  "OPENING": <OpeningPage />,
+  "SETTINGS": <Settings />
 }

--- a/src/providers/displayPower.js
+++ b/src/providers/displayPower.js
@@ -1,0 +1,23 @@
+export const getDisplayPower = async ({ signal } = {}) => {
+  const response = await fetch('/api/display', {
+    headers: { Accept: 'application/json' },
+    signal,
+  });
+  if (!response.ok) throw new Error(`Display service returned HTTP ${response.status}.`);
+  return response.json();
+};
+
+export const setDisplayPower = async (power, { signal } = {}) => {
+  if (power !== 'on' && power !== 'off') throw new Error('Invalid display power state.');
+  const response = await fetch('/api/display', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ power }),
+    signal,
+  });
+  if (!response.ok) throw new Error(`Display service returned HTTP ${response.status}.`);
+  return response.json();
+};

--- a/src/providers/systemPower.js
+++ b/src/providers/systemPower.js
@@ -1,0 +1,17 @@
+const allowedActions = new Set(['reboot', 'shutdown']);
+
+export const requestSystemPower = async (action, { signal } = {}) => {
+  if (!allowedActions.has(action)) throw new Error('Invalid system power action.');
+  const response = await fetch('/api/system/power', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ action }),
+    keepalive: true,
+    signal,
+  });
+  if (!response.ok) throw new Error(`System power service returned HTTP ${response.status}.`);
+  return response.json();
+};

--- a/test/displayPower.test.js
+++ b/test/displayPower.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getDisplayPower, setDisplayPower } from '../src/providers/displayPower.js';
+
+test('reads and updates display power through the narrow loopback API', async () => {
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, options = {}) => {
+    calls.push({ url, options });
+    return { ok: true, json: async () => ({ power: options.method === 'POST' ? 'off' : 'on' }) };
+  };
+  try {
+    assert.deepEqual(await getDisplayPower(), { power: 'on' });
+    assert.deepEqual(await setDisplayPower('off'), { power: 'off' });
+    assert.equal(calls[0].url, '/api/display');
+    assert.equal(JSON.parse(calls[1].options.body).power, 'off');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('rejects display states outside on and off', async () => {
+  await assert.rejects(() => setDisplayPower('toggle'), /Invalid display power state/);
+});

--- a/test/input.test.js
+++ b/test/input.test.js
@@ -7,6 +7,7 @@ import {
 } from '../src/helpers/inputMapping.js';
 
 test('maps standard navigation and Logitech-friendly media/browser keys', () => {
+  assert.equal(resolveKeyAction({ key: 'F13', code: 'F13' }), 'DISPLAY_TOGGLE');
   assert.equal(resolveKeyAction({ key: 'ArrowUp', code: 'ArrowUp' }), 'UP_CLICK');
   assert.equal(resolveKeyAction({ key: 'MediaTrackNext', code: '' }), 'DOWN_CLICK');
   assert.equal(resolveKeyAction({ key: 'BrowserForward', code: '' }), 'PRIMARY_CLICK');
@@ -14,8 +15,8 @@ test('maps standard navigation and Logitech-friendly media/browser keys', () => 
 });
 
 test('allows deployment-local mappings by key or code', () => {
-  const custom = { F13: 'UP_CLICK', NumpadAdd: 'PRIMARY_CLICK' };
-  assert.equal(resolveKeyAction({ key: 'F13', code: 'F13' }, custom), 'UP_CLICK');
+  const custom = { F14: 'UP_CLICK', NumpadAdd: 'PRIMARY_CLICK' };
+  assert.equal(resolveKeyAction({ key: 'F14', code: 'F14' }, custom), 'UP_CLICK');
   assert.equal(resolveKeyAction({ key: 'Unidentified', code: 'NumpadAdd' }, custom), 'PRIMARY_CLICK');
   assert.equal(resolveKeyAction({ key: 'F20', code: 'F20' }, custom), null);
 });

--- a/test/systemPower.test.js
+++ b/test/systemPower.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { requestSystemPower } from '../src/providers/systemPower.js';
+
+test('requests only allowlisted Pi power actions', async () => {
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, options = {}) => {
+    calls.push({ url, options });
+    return { ok: true, json: async () => ({ accepted: true, action: 'reboot' }) };
+  };
+  try {
+    assert.deepEqual(await requestSystemPower('reboot'), { accepted: true, action: 'reboot' });
+    assert.equal(calls[0].url, '/api/system/power');
+    assert.equal(calls[0].options.method, 'POST');
+    assert.equal(calls[0].options.keepalive, true);
+    assert.deepEqual(JSON.parse(calls[0].options.body), { action: 'reboot' });
+    await assert.rejects(() => requestSystemPower('sleep'), /Invalid system power action/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- map the Logitech Dialpad button to a smooth physical display fade and power toggle
- add a guarded Settings page for reboot and shutdown
- reduce menu and page-transition work for better Raspberry Pi responsiveness

## Stack
- Depends on #26
- Followed by the fish-tank, Linear, and Home Assistant PRs

## Testing
- npm run check