### PR TITLE
Add fish-tank screensaver

### DIFF
--- a/src/components/FishTankScreensaver.jsx
+++ b/src/components/FishTankScreensaver.jsx
@@ -1,0 +1,9 @@
+import { connect } from 'react-redux';
+import Aquarium from './aquarium/Aquarium.jsx';
+
+const mapDispatchToProps = (dispatch) => ({
+  onBack: () => dispatch({ type: 'BACK' }),
+  onMainMenu: () => dispatch({ type: 'OPEN_MAIN_MENU' }),
+});
+
+export const FishTankScreensaver = connect(null, mapDispatchToProps)(Aquarium);

--- a/src/components/ScreensaverMenu.jsx
+++ b/src/components/ScreensaverMenu.jsx
@@ -26,6 +26,11 @@ export const screensaverMenu = {
       color: "#FFE620",
       key: "MAP"
     },
+    {
+      name: "aquarium",
+      color: "#58D6C7",
+      key: "AQUARIUM"
+    },
 
   ]
 }

--- a/src/components/aquarium/Aquarium.css
+++ b/src/components/aquarium/Aquarium.css
@@ -1,0 +1,12 @@
+.aquarium {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  background: #03141b;
+}
+
+.aquarium canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}

--- a/src/components/aquarium/Aquarium.jsx
+++ b/src/components/aquarium/Aquarium.jsx
@@ -1,0 +1,162 @@
+import React, { useEffect, useRef } from 'react';
+import { MirrorEvents } from '../../helpers/events.jsx';
+import { advanceAquariumWorld, createAquariumWorld } from '../../providers/aquarium.js';
+import './Aquarium.css';
+
+const drawFish = (context, fish, width, height, elapsed) => {
+  const x = fish.x * width;
+  const y = (fish.y + Math.sin(elapsed * 0.7 + fish.phase) * 0.012) * height;
+  const size = Math.min(width, height) * 0.055 * fish.size;
+  const tailWave = Math.sin(elapsed * 5 + fish.phase) * 0.14;
+
+  context.save();
+  context.translate(x, y);
+  context.scale(fish.direction, 1);
+
+  context.fillStyle = fish.color;
+  context.beginPath();
+  context.moveTo(-size * 0.72, 0);
+  context.lineTo(-size * 1.28, -size * (0.55 + tailWave));
+  context.lineTo(-size * 1.2, size * (0.55 - tailWave));
+  context.closePath();
+  context.fill();
+
+  context.beginPath();
+  context.ellipse(0, 0, size, size * 0.52, 0, 0, Math.PI * 2);
+  context.fill();
+
+  context.globalAlpha = 0.28;
+  context.fillStyle = '#fff';
+  context.beginPath();
+  context.ellipse(size * 0.08, -size * 0.18, size * 0.58, size * 0.12, -0.15, 0, Math.PI * 2);
+  context.fill();
+  context.globalAlpha = 1;
+
+  context.fillStyle = '#f8fdff';
+  context.beginPath();
+  context.arc(size * 0.56, -size * 0.12, size * 0.105, 0, Math.PI * 2);
+  context.fill();
+  context.fillStyle = '#071117';
+  context.beginPath();
+  context.arc(size * 0.59, -size * 0.12, size * 0.052, 0, Math.PI * 2);
+  context.fill();
+  context.restore();
+};
+
+const drawPlant = (context, x, floor, height, elapsed, color) => {
+  context.strokeStyle = color;
+  context.lineWidth = 5;
+  context.lineCap = 'round';
+  context.beginPath();
+  context.moveTo(x, floor);
+  for (let step = 1; step <= 6; step += 1) {
+    const progress = step / 6;
+    context.lineTo(
+      x + Math.sin(elapsed * 0.35 + x * 0.01 + progress * 3) * 10 * progress,
+      floor - height * progress,
+    );
+  }
+  context.stroke();
+};
+
+export default function Aquarium({ onBack, onMainMenu }) {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const context = canvas.getContext('2d', { alpha: false });
+    const world = createAquariumWorld();
+    let frame;
+    let lastDraw = performance.now();
+    let gradient;
+
+    const resize = () => {
+      const width = Math.max(1, Math.floor(canvas.clientWidth));
+      const height = Math.max(1, Math.floor(canvas.clientHeight));
+      canvas.width = width;
+      canvas.height = height;
+      gradient = context.createLinearGradient(0, 0, 0, height);
+      gradient.addColorStop(0, '#082d3a');
+      gradient.addColorStop(0.58, '#075367');
+      gradient.addColorStop(1, '#062d32');
+    };
+
+    const draw = (timestamp) => {
+      frame = requestAnimationFrame(draw);
+      if (document.hidden || timestamp - lastDraw < 33) return;
+      const seconds = (timestamp - lastDraw) / 1000;
+      lastDraw = timestamp;
+      advanceAquariumWorld(world, seconds);
+
+      const { width, height } = canvas;
+      context.fillStyle = gradient;
+      context.fillRect(0, 0, width, height);
+
+      context.globalAlpha = 0.18;
+      context.fillStyle = '#baf6ff';
+      for (let ray = 0; ray < 4; ray += 1) {
+        context.beginPath();
+        context.moveTo(width * (0.08 + ray * 0.27), 0);
+        context.lineTo(width * (0.2 + ray * 0.27), height * 0.68);
+        context.lineTo(width * (0.35 + ray * 0.27), height * 0.68);
+        context.closePath();
+        context.fill();
+      }
+      context.globalAlpha = 1;
+
+      world.bubbles.forEach((bubble) => {
+        const x = (bubble.x + Math.sin(world.elapsed + bubble.phase) * 0.008) * width;
+        const y = bubble.y * height;
+        context.strokeStyle = 'rgba(210, 250, 255, 0.48)';
+        context.lineWidth = 1.3;
+        context.beginPath();
+        context.arc(x, y, bubble.radius, 0, Math.PI * 2);
+        context.stroke();
+      });
+
+      const floor = height * 0.96;
+      for (let plant = 0; plant < 9; plant += 1) {
+        drawPlant(
+          context,
+          width * (0.04 + plant * 0.12),
+          floor,
+          height * (0.08 + (plant % 3) * 0.035),
+          world.elapsed,
+          plant % 2 ? '#2aa88b' : '#45c58f',
+        );
+      }
+
+      context.fillStyle = '#876f58';
+      context.beginPath();
+      context.moveTo(0, height * 0.94);
+      for (let point = 0; point <= 12; point += 1) {
+        context.lineTo((point / 12) * width, height * (0.935 + (point % 2) * 0.014));
+      }
+      context.lineTo(width, height);
+      context.lineTo(0, height);
+      context.closePath();
+      context.fill();
+
+      world.fish.forEach((fish) => drawFish(context, fish, width, height, world.elapsed));
+    };
+
+    resize();
+    window.addEventListener('resize', resize);
+    const backListener = MirrorEvents.addListener('SECONDARY_CLICK', onBack);
+    const mainListener = MirrorEvents.addListener('SECONDARY_HOLD', onMainMenu);
+    frame = requestAnimationFrame(draw);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener('resize', resize);
+      backListener.remove();
+      mainListener.remove();
+    };
+  }, [onBack, onMainMenu]);
+
+  return (
+    <div className="aquarium">
+      <canvas ref={canvasRef} aria-label="Animated aquarium screensaver" />
+    </div>
+  );
+}

--- a/src/helpers/pages.jsx
+++ b/src/helpers/pages.jsx
@@ -9,6 +9,7 @@ import { QuotesPage } from '../components/quotes/Quotes.jsx'
 import { LockscreenScreensaver } from '../components/LockscreenScreensaver'
 import { WeatherContainer } from '../components/weather/Weather.jsx'
 import OpeningPage from '../components/goodmorning/Opening.jsx'
+import { FishTankScreensaver } from '../components/FishTankScreensaver.jsx';
 import Settings from '../components/settings/Settings.jsx';
 
 export const pages = {
@@ -22,5 +23,6 @@ export const pages = {
   "LOCKSCREEN": <LockscreenScreensaver />,
   "WEATHER": <WeatherContainer />,
   "OPENING": <OpeningPage />,
+  "AQUARIUM": <FishTankScreensaver />,
   "SETTINGS": <Settings />
 }

--- a/src/providers/aquarium.js
+++ b/src/providers/aquarium.js
@@ -1,0 +1,47 @@
+const palette = ['#ff8f70', '#ffcf66', '#58d6c7', '#67a7ff', '#b693ff', '#f47fb0'];
+
+const seededRandom = (seed = 9173) => {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 4294967296;
+  };
+};
+
+export const createAquariumWorld = ({ fishCount = 14, bubbleCount = 34, seed = 9173 } = {}) => {
+  const random = seededRandom(seed);
+  return {
+    elapsed: 0,
+    fish: Array.from({ length: fishCount }, (_, index) => ({
+      x: random(),
+      y: 0.12 + random() * 0.7,
+      speed: 0.018 + random() * 0.025,
+      direction: random() > 0.5 ? 1 : -1,
+      size: 0.65 + random() * 0.75,
+      phase: random() * Math.PI * 2,
+      color: palette[index % palette.length],
+    })),
+    bubbles: Array.from({ length: bubbleCount }, () => ({
+      x: 0.04 + random() * 0.92,
+      y: random(),
+      speed: 0.018 + random() * 0.035,
+      radius: 1.5 + random() * 3.5,
+      phase: random() * Math.PI * 2,
+    })),
+  };
+};
+
+export const advanceAquariumWorld = (world, seconds) => {
+  const delta = Math.min(Math.max(seconds, 0), 0.1);
+  world.elapsed += delta;
+  world.fish.forEach((fish) => {
+    fish.x += fish.speed * fish.direction * delta;
+    if (fish.direction > 0 && fish.x > 1.13) fish.x = -0.13;
+    if (fish.direction < 0 && fish.x < -0.13) fish.x = 1.13;
+  });
+  world.bubbles.forEach((bubble) => {
+    bubble.y -= bubble.speed * delta;
+    if (bubble.y < -0.02) bubble.y = 1.02;
+  });
+  return world;
+};

--- a/test/aquarium.test.js
+++ b/test/aquarium.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { advanceAquariumWorld, createAquariumWorld } from '../src/providers/aquarium.js';
+
+test('creates a deterministic, Pi-sized aquarium scene', () => {
+  const first = createAquariumWorld({ seed: 42 });
+  const second = createAquariumWorld({ seed: 42 });
+  assert.equal(first.fish.length, 14);
+  assert.equal(first.bubbles.length, 34);
+  assert.deepEqual(first.fish[0], second.fish[0]);
+});
+
+test('advances and wraps fish and bubbles within the scene', () => {
+  const world = createAquariumWorld({ fishCount: 1, bubbleCount: 1 });
+  world.fish[0].x = 1.14;
+  world.fish[0].direction = 1;
+  world.bubbles[0].y = -0.03;
+  advanceAquariumWorld(world, 0.05);
+  assert.equal(world.fish[0].x, -0.13);
+  assert.equal(world.bubbles[0].y, 1.02);
+});


### PR DESCRIPTION
## Summary
- add a lightweight animated aquarium designed for the Pi portrait display
- provide deterministic fish and bubble motion with bounded frame deltas
- expose it in the Screensavers menu with matching iconography

## Stack
- Depends on #27
- Followed by the Linear and Home Assistant PRs

## Testing
- npm run check