### PR TITLE
Add assigned Linear issues dashboard

### DIFF
--- a/src/components/MainMenu.jsx
+++ b/src/components/MainMenu.jsx
@@ -27,6 +27,11 @@ export const mainMenu = {
       key: "QUOTES"
     },
     {
+      name: "linear",
+      color: "#8E8EFF",
+      key: "LINEAR"
+    },
+    {
       name: "settings",
       color: "#FF9F0A",
       key: "SETTINGS"

--- a/src/components/linear/LinearIssues.css
+++ b/src/components/linear/LinearIssues.css
@@ -1,0 +1,142 @@
+.linear-page {
+  min-height: 100%;
+  padding: 48px 46px;
+  background: #08080a;
+  color: #f5f5f7;
+  letter-spacing: normal;
+}
+
+.linear-page__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 42px;
+}
+
+.linear-page h1 {
+  margin: 0;
+  font-size: 54px;
+  font-weight: 500;
+}
+
+.linear-page__count {
+  color: #8e8e93;
+  font-size: 22px;
+}
+
+.linear-page__list {
+  display: grid;
+  gap: 14px;
+}
+
+.linear-issue {
+  position: relative;
+  min-height: 148px;
+  padding: 24px 26px 22px 34px;
+  overflow: hidden;
+  border: 1px solid #242429;
+  border-radius: 20px;
+  background: #121216;
+}
+
+.linear-issue::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 7px;
+  background: var(--state-color, #5e6ad2);
+  content: '';
+}
+
+.linear-issue.is-selected {
+  border-color: #8e8eff;
+  background: #1c1c23;
+  box-shadow: 0 0 0 2px rgb(94 106 210 / 34%);
+}
+
+.linear-issue__meta {
+  display: flex;
+  gap: 16px;
+  color: #9a9aa1;
+  font-size: 18px;
+}
+
+.linear-issue__identifier {
+  color: #b6b6ff;
+  font-weight: 700;
+}
+
+.linear-issue__title {
+  margin-top: 12px;
+  font-size: 28px;
+  line-height: 1.23;
+}
+
+.linear-issue__details {
+  display: flex;
+  gap: 18px;
+  margin-top: 12px;
+  color: #77777f;
+  font-size: 17px;
+}
+
+.linear-page__notice {
+  margin: -22px 0 22px;
+  padding: 12px 16px;
+  border-radius: 10px;
+  background: #24211a;
+  color: #e2bd6b;
+  font-size: 18px;
+  text-align: center;
+}
+
+.linear-page__notice.is-error {
+  background: #2c191b;
+  color: #ff8b91;
+}
+
+.linear-page__message {
+  margin-top: 140px;
+  color: #a1a1a7;
+  text-align: center;
+  font-size: 28px;
+  line-height: 1.5;
+}
+
+.linear-confirm {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: grid;
+  place-items: center;
+  padding: 54px;
+  background: rgb(0 0 0 / 76%);
+  backdrop-filter: blur(14px);
+}
+
+.linear-confirm__card {
+  width: 100%;
+  padding: 46px 42px;
+  border: 1px solid #414149;
+  border-radius: 28px;
+  background: #19191f;
+  text-align: center;
+}
+
+.linear-confirm__eyebrow {
+  color: #8e8eff;
+  font-size: 20px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.linear-confirm__title {
+  margin: 24px 0 38px;
+  font-size: 34px;
+  line-height: 1.3;
+}
+
+.linear-confirm__hint {
+  color: #a1a1a7;
+  font-size: 21px;
+  line-height: 1.5;
+}

--- a/src/components/linear/LinearIssues.jsx
+++ b/src/components/linear/LinearIssues.jsx
@@ -1,0 +1,143 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { connect } from 'react-redux';
+import { MirrorEvents } from '../../helpers/events.jsx';
+import { completeAssignedIssue, fetchAssignedIssues } from '../../providers/linear.js';
+import './LinearIssues.css';
+
+const visibleWindow = (issues, selected) => {
+  const start = Math.max(0, Math.min(selected - 2, issues.length - 6));
+  return issues.slice(start, start + 6).map((issue, index) => ({ issue, absoluteIndex: start + index }));
+};
+
+function LinearIssues({ onBack, onMainMenu }) {
+  const [issues, setIssues] = useState([]);
+  const [selected, setSelected] = useState(0);
+  const [confirming, setConfirming] = useState(null);
+  const [status, setStatus] = useState('loading');
+  const [message, setMessage] = useState('Loading your assigned issues…');
+  const [stale, setStale] = useState(false);
+  const [mutationError, setMutationError] = useState('');
+
+  const load = useCallback(async (signal) => {
+    setStatus('loading');
+    try {
+      const result = await fetchAssignedIssues({ signal });
+      setIssues(result.issues || []);
+      setStale(result.stale === true);
+      setSelected(0);
+      setStatus('ready');
+    } catch (error) {
+      if (error.name === 'AbortError') return;
+      setMessage(error.message);
+      setStatus('error');
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    load(controller.signal);
+    return () => controller.abort();
+  }, [load]);
+
+  useEffect(() => {
+    const listeners = [
+      MirrorEvents.addListener('UP_CLICK', () => {
+        if (!confirming) setSelected((current) => Math.max(0, current - 1));
+      }),
+      MirrorEvents.addListener('DOWN_CLICK', () => {
+        if (!confirming) setSelected((current) => Math.min(issues.length - 1, current + 1));
+      }),
+      MirrorEvents.addListener('PRIMARY_CLICK', async () => {
+        if (status === 'error') {
+          load();
+          return;
+        }
+        const issue = issues[selected];
+        if (!issue || status === 'saving') return;
+        if (!confirming) {
+          setMutationError('');
+          setConfirming(issue.id);
+          return;
+        }
+        setStatus('saving');
+        try {
+          await completeAssignedIssue(confirming);
+          const remaining = issues.filter((item) => item.id !== confirming);
+          setIssues(remaining);
+          setSelected((current) => Math.max(0, Math.min(current, remaining.length - 1)));
+          setConfirming(null);
+          setStatus('ready');
+        } catch (error) {
+          setMutationError(error.message);
+          setConfirming(null);
+          setStatus('ready');
+        }
+      }),
+      MirrorEvents.addListener('SECONDARY_CLICK', () => {
+        if (confirming) setConfirming(null);
+        else onBack();
+      }),
+      MirrorEvents.addListener('SECONDARY_HOLD', onMainMenu),
+    ];
+    return () => listeners.forEach((listener) => listener.remove());
+  }, [confirming, issues, load, onBack, onMainMenu, selected, status]);
+
+  const selectedIssue = issues.find((issue) => issue.id === confirming);
+
+  return (
+    <main className="linear-page">
+      <header className="linear-page__header">
+        <h1>My Linear</h1>
+        <span className="linear-page__count">{issues.length} open</span>
+      </header>
+
+      {stale && <div className="linear-page__notice">Offline — showing the last saved task list.</div>}
+      {mutationError && <div className="linear-page__notice is-error">{mutationError}</div>}
+
+      {status === 'loading' && <div className="linear-page__message">Loading your assigned issues…</div>}
+      {status === 'error' && <div className="linear-page__message">{message}<br />Select to retry.</div>}
+      {status !== 'loading' && status !== 'error' && issues.length === 0
+        && <div className="linear-page__message">Nothing assigned. A rare and beautiful sight.</div>}
+
+      <section className="linear-page__list">
+        {status !== 'loading' && visibleWindow(issues, selected).map(({ issue, absoluteIndex }) => (
+          <article
+            className={`linear-issue${absoluteIndex === selected ? ' is-selected' : ''}`}
+            style={{ '--state-color': issue.state?.color }}
+            key={issue.id}
+          >
+            <div className="linear-issue__meta">
+              <span className="linear-issue__identifier">{issue.identifier}</span>
+              <span>{issue.state?.name}</span>
+              {issue.project?.name && <span>{issue.project.name}</span>}
+            </div>
+            <div className="linear-issue__title">{issue.title}</div>
+            <div className="linear-issue__details">
+              <span>{['No priority', 'Urgent', 'High', 'Medium', 'Low'][issue.priority || 0]}</span>
+              {issue.dueDate && <span>Due {issue.dueDate}</span>}
+            </div>
+          </article>
+        ))}
+      </section>
+
+      {selectedIssue && (
+        <div className="linear-confirm">
+          <div className="linear-confirm__card">
+            <div className="linear-confirm__eyebrow">Complete {selectedIssue.identifier}?</div>
+            <div className="linear-confirm__title">{selectedIssue.title}</div>
+            <div className="linear-confirm__hint">
+              Press select again to complete.<br />Press back to cancel.
+            </div>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}
+
+const mapDispatchToProps = (dispatch) => ({
+  onBack: () => dispatch({ type: 'BACK' }),
+  onMainMenu: () => dispatch({ type: 'OPEN_MAIN_MENU' }),
+});
+
+export default connect(null, mapDispatchToProps)(LinearIssues);

--- a/src/helpers/pages.jsx
+++ b/src/helpers/pages.jsx
@@ -10,6 +10,7 @@ import { LockscreenScreensaver } from '../components/LockscreenScreensaver'
 import { WeatherContainer } from '../components/weather/Weather.jsx'
 import OpeningPage from '../components/goodmorning/Opening.jsx'
 import { FishTankScreensaver } from '../components/FishTankScreensaver.jsx';
+import LinearIssues from '../components/linear/LinearIssues.jsx';
 import Settings from '../components/settings/Settings.jsx';
 
 export const pages = {
@@ -24,5 +25,6 @@ export const pages = {
   "WEATHER": <WeatherContainer />,
   "OPENING": <OpeningPage />,
   "AQUARIUM": <FishTankScreensaver />,
+  "LINEAR": <LinearIssues />,
   "SETTINGS": <Settings />
 }

--- a/src/providers/linear.js
+++ b/src/providers/linear.js
@@ -1,0 +1,32 @@
+const readJson = async (response) => {
+  let payload;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new Error('Linear integration is unavailable.');
+  }
+  if (!response.ok) throw new Error(payload.error || `Linear service returned HTTP ${response.status}.`);
+  return payload;
+};
+
+export const fetchAssignedIssues = async ({ signal } = {}) => {
+  const response = await fetch('/api/linear/issues', {
+    headers: { Accept: 'application/json' },
+    signal,
+  });
+  return readJson(response);
+};
+
+export const completeAssignedIssue = async (id, { signal } = {}) => {
+  if (!id) throw new Error('A Linear issue ID is required.');
+  const response = await fetch('/api/linear/issues/complete', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ id }),
+    signal,
+  });
+  return readJson(response);
+};

--- a/test/linear.test.js
+++ b/test/linear.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { completeAssignedIssue, fetchAssignedIssues } from '../src/providers/linear.js';
+
+test('loads assigned issues and completes only a specified issue', async () => {
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, options = {}) => {
+    calls.push({ url, options });
+    return {
+      ok: true,
+      json: async () => (options.method === 'POST' ? { issue: { id: 'issue-1' } } : { issues: [] }),
+    };
+  };
+  try {
+    assert.deepEqual(await fetchAssignedIssues(), { issues: [] });
+    assert.deepEqual(await completeAssignedIssue('issue-1'), { issue: { id: 'issue-1' } });
+    assert.equal(calls[1].url, '/api/linear/issues/complete');
+    assert.deepEqual(JSON.parse(calls[1].options.body), { id: 'issue-1' });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('refuses a completion request without an issue ID', async () => {
+  await assert.rejects(() => completeAssignedIssue(''), /required/);
+});


### PR DESCRIPTION
## Summary
- show active issues assigned to the configured Linear user
- add a two-step completion flow that revalidates assignment server-side
- keep the Linear API key in a root-owned Pi environment file

## Stack
- Depends on #28
- Followed by the Home Assistant PR

## Testing
- npm run check