### PR TITLE
Add Home Assistant status dashboard

### DIFF
--- a/public/reflectrum-config.js
+++ b/public/reflectrum-config.js
@@ -3,6 +3,9 @@
 window.REFLECTRUM_CONFIG = {
   username: 'Michelle',
   // location: { lat: 0, long: 0, name: 'City, State' },
+  // homeAssistant: {
+  //   historyEntities: ['sensor.outdoor_temperature', 'sensor.internet_download_speed'],
+  // },
   // inputDiagnostics: true,
   // input: {
   //   keyMap: { F13: 'UP_CLICK', F14: 'DOWN_CLICK' },

--- a/src/components/MainMenu.jsx
+++ b/src/components/MainMenu.jsx
@@ -32,6 +32,11 @@ export const mainMenu = {
       key: "LINEAR"
     },
     {
+      name: "home",
+      color: "#6FB3FF",
+      key: "HOME"
+    },
+    {
       name: "settings",
       color: "#FF9F0A",
       key: "SETTINGS"

--- a/src/components/home/HomeDashboard.css
+++ b/src/components/home/HomeDashboard.css
@@ -1,0 +1,126 @@
+.home-dashboard {
+  min-height: 100%;
+  padding: 42px 38px;
+  background: radial-gradient(circle at 85% 0%, #152334 0, #080b10 36%, #050607 100%);
+  color: #f3f5f7;
+  letter-spacing: normal;
+}
+
+.home-dashboard__topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.home-dashboard h1 {
+  margin: 0;
+  font-size: 50px;
+  font-weight: 540;
+}
+
+.home-dashboard__updated {
+  color: #87909a;
+  font-size: 17px;
+}
+
+.home-dashboard__tabs {
+  display: flex;
+  gap: 8px;
+  margin: 30px 0 32px;
+}
+
+.home-dashboard__tab {
+  flex: 1;
+  padding: 11px 4px;
+  border-radius: 12px;
+  background: #141920;
+  color: #77808b;
+  text-align: center;
+  font-size: 16px;
+  text-transform: capitalize;
+}
+
+.home-dashboard__tab.is-active {
+  background: #e9f2ff;
+  color: #10151b;
+}
+
+.home-dashboard__notice {
+  margin-bottom: 22px;
+  color: #e3ba68;
+  text-align: center;
+  font-size: 17px;
+}
+
+.home-dashboard__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.home-card {
+  min-height: 150px;
+  padding: 21px 22px;
+  border: 1px solid #202833;
+  border-radius: 20px;
+  background: rgb(17 22 28 / 88%);
+}
+
+.home-card__name {
+  min-height: 42px;
+  overflow: hidden;
+  color: #aab2bc;
+  font-size: 18px;
+  line-height: 1.2;
+}
+
+.home-card__state {
+  margin-top: 10px;
+  font-size: 31px;
+  line-height: 1.1;
+}
+
+.home-card__state.is-alert {
+  color: #ff867c;
+}
+
+.home-card__sparkline {
+  width: 100%;
+  height: 40px;
+  margin-top: 12px;
+  overflow: visible;
+}
+
+.home-card__sparkline polyline {
+  fill: none;
+  stroke: #6fb3ff;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2.5;
+}
+
+.home-summary {
+  min-height: 210px;
+  padding: 28px;
+  border-radius: 24px;
+  background: rgb(18 25 33 / 90%);
+}
+
+.home-summary__number {
+  font-size: 70px;
+}
+
+.home-summary__label {
+  margin-top: 12px;
+  color: #9ca5af;
+  font-size: 22px;
+  text-transform: capitalize;
+}
+
+.home-dashboard__empty {
+  margin-top: 180px;
+  color: #88919b;
+  text-align: center;
+  font-size: 27px;
+  line-height: 1.5;
+}

--- a/src/components/home/HomeDashboard.jsx
+++ b/src/components/home/HomeDashboard.jsx
@@ -1,0 +1,163 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { connect } from 'react-redux';
+import { MirrorEvents } from '../../helpers/events.jsx';
+import {
+  fetchHomeEntities,
+  fetchHomeHistory,
+  groupHomeEntities,
+} from '../../providers/homeAssistant.js';
+import './HomeDashboard.css';
+
+const sections = ['overview', 'locks', 'lights', 'sensors', 'network'];
+
+const stateIsAlert = (entity) => {
+  const domain = entity.entityId?.split('.')[0];
+  if (domain === 'lock') return entity.state !== 'locked';
+  if (domain === 'binary_sensor') return entity.state === 'on';
+  return ['unavailable', 'unknown', 'problem'].includes(entity.state);
+};
+
+const Sparkline = ({ points }) => {
+  if (!points || points.length < 2) return null;
+  const values = points.map((point) => point.value);
+  const minimum = Math.min(...values);
+  const range = Math.max(0.0001, Math.max(...values) - minimum);
+  const coordinates = points.map((point, index) => {
+    const x = (index / (points.length - 1)) * 100;
+    const y = 36 - ((point.value - minimum) / range) * 32;
+    return `${x},${y}`;
+  }).join(' ');
+  return (
+    <svg className="home-card__sparkline" viewBox="0 0 100 40" preserveAspectRatio="none" aria-hidden="true">
+      <polyline points={coordinates} />
+    </svg>
+  );
+};
+
+function HomeDashboard({ onBack, onMainMenu }) {
+  const [sectionIndex, setSectionIndex] = useState(0);
+  const [entities, setEntities] = useState([]);
+  const [history, setHistory] = useState({});
+  const [status, setStatus] = useState('loading');
+  const [message, setMessage] = useState('Connecting to Home Assistant…');
+  const [stale, setStale] = useState(false);
+  const [updatedAt, setUpdatedAt] = useState(null);
+  const [historyError, setHistoryError] = useState('');
+  const requestRef = useRef(null);
+
+  const load = useCallback(async () => {
+    requestRef.current?.abort();
+    const controller = new AbortController();
+    requestRef.current = controller;
+    setStatus('loading');
+    setHistoryError('');
+    try {
+      const result = await fetchHomeEntities({ signal: controller.signal });
+      const nextEntities = result.entities || [];
+      setEntities(nextEntities);
+      setStale(result.stale === true);
+      setUpdatedAt(new Date());
+      setStatus('ready');
+
+      const configured = globalThis.REFLECTRUM_CONFIG?.homeAssistant?.historyEntities || [];
+      const numeric = nextEntities
+        .filter((entity) => Number.isFinite(Number(entity.state)))
+        .map((entity) => entity.entityId);
+      const historyEntities = [...new Set([...configured, ...numeric])].slice(0, 8);
+      try {
+        const historyResult = await fetchHomeHistory(historyEntities, { signal: controller.signal });
+        setHistory(Object.fromEntries(historyResult.series.map((series) => [series.entityId, series.points])));
+      } catch (error) {
+        if (error.name !== 'AbortError') setHistoryError('Current state is live, but history is unavailable.');
+      }
+    } catch (error) {
+      if (error.name !== 'AbortError') {
+        setMessage(error.message);
+        setStatus('error');
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+    return () => requestRef.current?.abort();
+  }, [load]);
+
+  useEffect(() => {
+    const listeners = [
+      MirrorEvents.addListener('UP_CLICK', () => setSectionIndex((current) => Math.max(0, current - 1))),
+      MirrorEvents.addListener('DOWN_CLICK', () => setSectionIndex((current) => Math.min(sections.length - 1, current + 1))),
+      MirrorEvents.addListener('PRIMARY_CLICK', load),
+      MirrorEvents.addListener('SECONDARY_CLICK', onBack),
+      MirrorEvents.addListener('SECONDARY_HOLD', onMainMenu),
+    ];
+    return () => listeners.forEach((listener) => listener.remove());
+  }, [load, onBack, onMainMenu]);
+
+  const grouped = useMemo(() => groupHomeEntities(entities), [entities]);
+  const activeSection = sections[sectionIndex];
+  const visibleEntities = activeSection === 'overview' ? [] : grouped[activeSection].slice(0, 12);
+
+  return (
+    <main className="home-dashboard">
+      <div className="home-dashboard__topline">
+        <h1>Home</h1>
+        <span className="home-dashboard__updated">
+          {updatedAt ? `Updated ${updatedAt.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}` : ''}
+        </span>
+      </div>
+      <div className="home-dashboard__tabs">
+        {sections.map((section, index) => (
+          <div className={`home-dashboard__tab${index === sectionIndex ? ' is-active' : ''}`} key={section}>
+            {section}
+          </div>
+        ))}
+      </div>
+
+      {stale && <div className="home-dashboard__notice">Offline — showing the latest saved state.</div>}
+      {historyError && <div className="home-dashboard__notice">{historyError}</div>}
+      {status === 'loading' && <div className="home-dashboard__empty">Connecting to Home Assistant…</div>}
+      {status === 'error' && <div className="home-dashboard__empty">{message}<br />Select to retry.</div>}
+
+      {status === 'ready' && activeSection === 'overview' && (
+        <section className="home-dashboard__grid">
+          {Object.entries(grouped).map(([name, values]) => (
+            <article className="home-summary" key={name}>
+              <div className="home-summary__number">
+                {name === 'locks'
+                  ? values.filter((entity) => stateIsAlert(entity)).length
+                  : values.length}
+              </div>
+              <div className="home-summary__label">
+                {name === 'locks' ? 'locks needing attention' : name}
+              </div>
+            </article>
+          ))}
+        </section>
+      )}
+
+      {status === 'ready' && activeSection !== 'overview' && visibleEntities.length === 0
+        && <div className="home-dashboard__empty">No {activeSection} entities discovered yet.</div>}
+      {status === 'ready' && activeSection !== 'overview' && (
+        <section className="home-dashboard__grid">
+          {visibleEntities.map((entity) => (
+            <article className="home-card" key={entity.entityId}>
+              <div className="home-card__name">{entity.name}</div>
+              <div className={`home-card__state${stateIsAlert(entity) ? ' is-alert' : ''}`}>
+                {entity.state}{entity.unit ? ` ${entity.unit}` : ''}
+              </div>
+              <Sparkline points={history[entity.entityId]} />
+            </article>
+          ))}
+        </section>
+      )}
+    </main>
+  );
+}
+
+const mapDispatchToProps = (dispatch) => ({
+  onBack: () => dispatch({ type: 'BACK' }),
+  onMainMenu: () => dispatch({ type: 'OPEN_MAIN_MENU' }),
+});
+
+export default connect(null, mapDispatchToProps)(HomeDashboard);

--- a/src/helpers/pages.jsx
+++ b/src/helpers/pages.jsx
@@ -11,6 +11,7 @@ import { WeatherContainer } from '../components/weather/Weather.jsx'
 import OpeningPage from '../components/goodmorning/Opening.jsx'
 import { FishTankScreensaver } from '../components/FishTankScreensaver.jsx';
 import LinearIssues from '../components/linear/LinearIssues.jsx';
+import HomeDashboard from '../components/home/HomeDashboard.jsx';
 import Settings from '../components/settings/Settings.jsx';
 
 export const pages = {
@@ -26,5 +27,6 @@ export const pages = {
   "OPENING": <OpeningPage />,
   "AQUARIUM": <FishTankScreensaver />,
   "LINEAR": <LinearIssues />,
+  "HOME": <HomeDashboard />,
   "SETTINGS": <Settings />
 }

--- a/src/providers/homeAssistant.js
+++ b/src/providers/homeAssistant.js
@@ -1,0 +1,40 @@
+const responseJson = async (response) => {
+  let payload;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new Error('Home Assistant integration is unavailable.');
+  }
+  if (!response.ok) throw new Error(payload.error || `Home service returned HTTP ${response.status}.`);
+  return payload;
+};
+
+export const fetchHomeEntities = async ({ signal } = {}) => {
+  const response = await fetch('/api/home/states', {
+    headers: { Accept: 'application/json' },
+    signal,
+  });
+  return responseJson(response);
+};
+
+export const fetchHomeHistory = async (entities, { hours = 24, signal } = {}) => {
+  if (!Array.isArray(entities) || entities.length === 0) return { series: [], hours };
+  const query = new URLSearchParams({ entities: entities.join(','), hours: String(hours) });
+  const response = await fetch(`/api/home/history?${query}`, {
+    headers: { Accept: 'application/json' },
+    signal,
+  });
+  return responseJson(response);
+};
+
+export const groupHomeEntities = (entities) => {
+  const networkPattern = /(unifi|network|internet|wan|wifi|wlan|throughput|download|upload)/i;
+  const domain = (entity) => entity.entityId?.split('.')[0];
+  return {
+    locks: entities.filter((entity) => domain(entity) === 'lock'),
+    lights: entities.filter((entity) => domain(entity) === 'light'),
+    sensors: entities.filter((entity) => ['sensor', 'binary_sensor'].includes(domain(entity))
+      && !networkPattern.test(`${entity.entityId} ${entity.name}`)),
+    network: entities.filter((entity) => networkPattern.test(`${entity.entityId} ${entity.name}`)),
+  };
+};

--- a/test/homeAssistant.test.js
+++ b/test/homeAssistant.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  fetchHomeEntities,
+  fetchHomeHistory,
+  groupHomeEntities,
+} from '../src/providers/homeAssistant.js';
+
+test('groups home entities without requiring deployment-specific IDs', () => {
+  const groups = groupHomeEntities([
+    { entityId: 'lock.front_door', name: 'Front Door' },
+    { entityId: 'light.kitchen', name: 'Kitchen' },
+    { entityId: 'sensor.outdoor_temperature', name: 'Outdoor Temperature' },
+    { entityId: 'sensor.unifi_wan_download', name: 'WAN Download' },
+  ]);
+  assert.equal(groups.locks.length, 1);
+  assert.equal(groups.lights.length, 1);
+  assert.equal(groups.sensors.length, 1);
+  assert.equal(groups.network.length, 1);
+});
+
+test('loads current state and bounded history through read-only endpoints', async () => {
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url) => {
+    calls.push(url);
+    return { ok: true, json: async () => (url.includes('history') ? { series: [] } : { entities: [] }) };
+  };
+  try {
+    assert.deepEqual(await fetchHomeEntities(), { entities: [] });
+    assert.deepEqual(await fetchHomeHistory(['sensor.temperature']), { series: [] });
+    assert.match(calls[1], /entities=sensor\.temperature/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- add a read-only dashboard for locks, lights, sensors, and network entities
- fetch allowlisted state fields and bounded numeric history through the Pi service
- support deployment-specific priority entities without committing credentials

## Stack
- Depends on #29
- Final PR in the stack

## Testing
- npm run check