### PR TITLE
Optimize Raspberry Pi rendering with Cog direct DRM

### DIFF
--- a/deploy/42-reflectrum-logitech-permissions.rules
+++ b/deploy/42-reflectrum-logitech-permissions.rules
@@ -1,6 +1,6 @@
 # Vendored from Solaar 1.1.19 rules.d-uinput/42-logitech-unify-permissions.rules.
-# Allows the logged-in desktop user to read Logitech HID++ and emit uinput keys.
-KERNEL=="uinput", SUBSYSTEM=="misc", TAG+="uaccess", OPTIONS+="static_node=uinput"
+# Allows the dedicated input service to read Logitech HID++ and emit uinput keys.
+KERNEL=="uinput", SUBSYSTEM=="misc", GROUP="input", MODE="0660", OPTIONS+="static_node=uinput"
 
 ACTION == "remove", GOTO="solaar_end"
 SUBSYSTEM != "hidraw", GOTO="solaar_end"
@@ -12,6 +12,7 @@ KERNELS == "0005:046D:*", GOTO="solaar_apply"
 GOTO="solaar_end"
 
 LABEL="solaar_apply"
+GROUP="input", MODE="0660"
 TAG+="uaccess"
 
 LABEL="solaar_end"

--- a/deploy/99-reflectrum-zram.conf
+++ b/deploy/99-reflectrum-zram.conf
@@ -1,0 +1,3 @@
+# Prefer compressed RAM over slow SD-card swap on memory-constrained kiosks.
+vm.swappiness=100
+vm.page-cluster=0

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -50,7 +50,8 @@ The performance setup launches Chromium's native binary directly under Wayland,
 avoiding the desktop wrapper's accessibility and extension flags. On a Pi 3 it
 also caps renderer processes and adds `performance=low` to the kiosk URL.
 Override automatic detection with `REFLECTRUM_PERFORMANCE_MODE=normal` or `low`
-in `/etc/reflectrum/kiosk.env`.
+in `/etc/reflectrum/kiosk.env`. Low mode also reduces the Dialpad wheel throttle
+from 90 ms to 40 ms and shortens the menu highlight motion from 180 ms to 55 ms.
 
 `reflectrum-zram.service` allocates 50% of physical RAM as fast compressed swap
 and disables `dphys-swapfile`; the existing `/var/swap` file is left intact for
@@ -71,8 +72,9 @@ pgrep -af /usr/lib/chromium/chromium
 
 The screen-share launcher favors responsiveness on the Raspberry Pi 3: it
 disables remote resizing, reduces Tight/JPEG quality, lowers compression work,
-and rate-limits pointer updates. Set `REFLECTRUM_VNC_LOCAL_PORT` if port 5900 is
-already used locally.
+and rate-limits pointer updates. WayVNC stays disabled between sessions; the
+launcher starts it before opening TigerVNC and stops it when the viewer exits.
+Set `REFLECTRUM_VNC_LOCAL_PORT` if port 5900 is already used locally.
 
 The live Motorola display identifies as `HDMI-A-1`, with a preferred mode of
 1366×768 at 60 Hz. After the 90-degree Wayland transform, applications see a

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -6,8 +6,7 @@ Reflectrum coexists with the FlightAware feeder:
 - `reflectrum-web.service` serves the static build on loopback port 3000.
 - the desktop autostart entry rotates `HDMI-A-1` 90 degrees with `wlr-randr`
   and opens Chromium in kiosk mode.
-- Pi 3 hardware automatically uses a low-overhead Chromium profile and skips
-  snapshot-based page transitions.
+- Pi 3 hardware automatically uses a low-overhead Chromium profile.
 - compressed RAM swap replaces the SD-card swap file.
 - `wlsunset` adjusts display color temperature through labwc's Wayland gamma
   controls; Night Shift is not rendered inside Chromium.
@@ -46,12 +45,14 @@ DHCP address changes do not require script updates. Override it with
 `/opt/reflectrum/reflectrum-config.js` and `/etc/reflectrum/calendar.env`
 untouched.
 
-The performance setup launches Chromium's native binary directly under Wayland,
-avoiding the desktop wrapper's accessibility and extension flags. On a Pi 3 it
-also caps renderer processes and adds `performance=low` to the kiosk URL.
+The performance setup launches Chromium's native binary directly, avoiding the
+desktop wrapper's accessibility and extension flags. On a Pi 3 it also uses the
+slightly smoother X11 backend, caps renderer processes, and adds
+`performance=low` to the kiosk URL.
 Override automatic detection with `REFLECTRUM_PERFORMANCE_MODE=normal` or `low`
 in `/etc/reflectrum/kiosk.env`. Low mode also reduces the Dialpad wheel throttle
-from 90 ms to 40 ms and shortens the menu highlight motion from 180 ms to 55 ms.
+from 90 ms to 40 ms. Set `REFLECTRUM_OZONE_PLATFORM=x11` there to use Xwayland
+instead of Chromium's native Wayland backend for graphics comparison.
 
 `reflectrum-zram.service` allocates 50% of physical RAM as fast compressed swap
 and disables `dphys-swapfile`; the existing `/var/swap` file is left intact for

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -47,12 +47,19 @@ untouched.
 
 The performance setup launches Chromium's native binary directly, avoiding the
 desktop wrapper's accessibility and extension flags. On a Pi 3 it also uses the
-slightly smoother X11 backend, caps renderer processes, and adds
-`performance=low` to the kiosk URL.
+slightly smoother X11 backend, renders at 720×480 at 60 Hz, caps renderer
+processes, and adds `performance=low` to the kiosk URL.
 Override automatic detection with `REFLECTRUM_PERFORMANCE_MODE=normal` or `low`
 in `/etc/reflectrum/kiosk.env`. Low mode also reduces the Dialpad wheel throttle
 from 90 ms to 40 ms. Set `REFLECTRUM_OZONE_PLATFORM=x11` there to use Xwayland
 instead of Chromium's native Wayland backend for graphics comparison.
+
+Override the automatic Pi 3 resolution in `/etc/reflectrum/kiosk.env` when
+needed. For example, restore the display's native mode with:
+
+```ini
+REFLECTRUM_DISPLAY_MODE=1366x768@60Hz
+```
 
 `reflectrum-zram.service` allocates 50% of physical RAM as fast compressed swap
 and disables `dphys-swapfile`; the existing `/var/swap` file is left intact for

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -47,11 +47,13 @@ untouched.
 
 The performance setup launches Chromium's native binary directly, avoiding the
 desktop wrapper's accessibility and extension flags. On a Pi 3 it also uses the
-slightly smoother X11 backend, renders at 720×480 at 60 Hz, caps renderer
-processes, and adds `performance=low` to the kiosk URL.
+slightly smoother X11 backend, renders at 854×480 at 60 Hz, caps renderer
+processes, and adds `performance=low` to the kiosk URL. A 0.625 Chromium device
+scale preserves the original 768×1366 logical layout at the lower resolution.
 Override automatic detection with `REFLECTRUM_PERFORMANCE_MODE=normal` or `low`
-in `/etc/reflectrum/kiosk.env`. Low mode also reduces the Dialpad wheel throttle
-from 90 ms to 40 ms. Set `REFLECTRUM_OZONE_PLATFORM=x11` there to use Xwayland
+in `/etc/reflectrum/kiosk.env`. Low mode uses a 110 ms Dialpad wheel throttle and
+a 100 ms menu-highlight animation so sensitive wheel events do not continually
+restart the animation. Set `REFLECTRUM_OZONE_PLATFORM=x11` there to use Xwayland
 instead of Chromium's native Wayland backend for graphics comparison.
 
 Override the automatic Pi 3 resolution in `/etc/reflectrum/kiosk.env` when
@@ -59,6 +61,8 @@ needed. For example, restore the display's native mode with:
 
 ```ini
 REFLECTRUM_DISPLAY_MODE=1366x768@60Hz
+REFLECTRUM_DISPLAY_MODE_KIND=standard
+REFLECTRUM_DEVICE_SCALE_FACTOR=1
 ```
 
 `reflectrum-zram.service` allocates 50% of physical RAM as fast compressed swap

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -4,18 +4,24 @@ Reflectrum coexists with the FlightAware feeder:
 
 - ADS-B retains Lighttpd and its existing ports.
 - `reflectrum-web.service` serves the static build on loopback port 3000.
-- the desktop autostart entry rotates `HDMI-A-1` 90 degrees with `wlr-randr`
-  and opens Chromium in kiosk mode.
-- Pi 3 hardware automatically uses a low-overhead Chromium profile.
+- `reflectrum-cog.service` opens WPE WebKit directly on DRM/KMS, rotates the
+  native display 90 degrees, and avoids a desktop compositor entirely.
+- `reflectrum-solaar-headless.service` translates the MX Creative Dialpad's
+  vendor buttons and two wheel directions into ordinary Linux keys.
 - compressed RAM swap replaces the SD-card swap file.
-- `wlsunset` adjusts display color temperature through labwc's Wayland gamma
-  controls; Night Shift is not rendered inside Chromium.
 
 Build on a development computer so the Pi does not need Node.js:
 
 ```sh
 npm ci
 npm run build
+```
+
+The Pi needs Cog/WPE, Chromium as the recovery renderer, Solaar, and the
+existing Wayland utilities used by that fallback:
+
+```sh
+sudo apt install acl cog chromium solaar wlr-randr wlsunset
 ```
 
 Copy the checkout, including `dist/`, to the Pi and run:
@@ -30,14 +36,13 @@ command per task:
 
 ```sh
 npm run pi:deploy       # check, build, copy generated assets, restart kiosk
-npm run pi:refresh      # restart Chromium without rebuilding
-npm run pi:screenshare  # restore the SSH tunnel and open tuned TigerVNC
+npm run pi:refresh      # restart Cog and its input bridge without rebuilding
+npm run pi:screenshare  # open TigerVNC when using the Chromium fallback
 ```
 
-`pi:deploy` also installs the tracked loopback server, systemd units, and Solaar
-rules while preserving all deployment-local config and secret environment files.
-Reboot once when the Dialpad rule changes so the running Solaar session reloads
-it.
+`pi:deploy` also installs the tracked loopback server, renderer and input
+services, udev permissions, and Solaar rules while preserving all
+deployment-local config and secret environment files.
 
 These commands use the Raspberry Pi's `adsb.local` mDNS name by default, so
 DHCP address changes do not require script updates. Override it with
@@ -45,25 +50,23 @@ DHCP address changes do not require script updates. Override it with
 `/opt/reflectrum/reflectrum-config.js` and `/etc/reflectrum/calendar.env`
 untouched.
 
-The performance setup launches Chromium's native binary directly, avoiding the
-desktop wrapper's accessibility and extension flags. On a Pi 3 it also uses the
-slightly smoother X11 backend, renders at 854×480 at 60 Hz, caps renderer
-processes, and adds `performance=low` to the kiosk URL. A 0.625 Chromium device
-scale preserves the original 768×1366 logical layout at the lower resolution.
-Override automatic detection with `REFLECTRUM_PERFORMANCE_MODE=normal` or `low`
-in `/etc/reflectrum/kiosk.env`. Low mode uses a 110 ms Dialpad wheel throttle and
-a 100 ms menu-highlight animation so sensitive wheel events do not continually
-restart the animation. Set `REFLECTRUM_OZONE_PLATFORM=x11` there to use Xwayland
-instead of Chromium's native Wayland backend for graphics comparison.
-
-Override the automatic Pi 3 resolution in `/etc/reflectrum/kiosk.env` when
-needed. For example, restore the display's native mode with:
+Cog is the default Pi renderer because its direct-DRM path avoids Chromium,
+Xwayland, and labwc composition overhead. It runs the live display at its native
+1366×768 mode and rotates the GLES output 90 degrees clockwise. The application
+keeps its low-memory behavior through `performance=low`, while retaining smooth
+CSS transitions at the native scale. Optional settings belong in
+`/etc/reflectrum/cog.env`:
 
 ```ini
-REFLECTRUM_DISPLAY_MODE=1366x768@60Hz
-REFLECTRUM_DISPLAY_MODE_KIND=standard
+REFLECTRUM_COG_VIDEO_MODE=1366x768
+REFLECTRUM_COG_ROTATION=3
 REFLECTRUM_DEVICE_SCALE_FACTOR=1
+REFLECTRUM_COG_MEMORY_LIMIT=512
 ```
+
+`REFLECTRUM_COG_ROTATION` is the number of counter-clockwise 90-degree
+increments; `3` is 90 degrees clockwise. The installed Cog 0.16 Wayland plug-in
+is not used because it aborts while exporting DMA buffers on this Pi image.
 
 `reflectrum-zram.service` allocates 50% of physical RAM as fast compressed swap
 and disables `dphys-swapfile`; the existing `/var/swap` file is left intact for
@@ -74,23 +77,22 @@ REFLECTRUM_ZRAM_PERCENT=50
 REFLECTRUM_ZRAM_ALGORITHM=lz4
 ```
 
-Verify the active swap and lean browser command with:
+Verify the active swap and renderer command with:
 
 ```sh
 swapon --show
 systemctl status reflectrum-zram
-pgrep -af /usr/lib/chromium/chromium
+pgrep -af '/usr/bin/cog|/usr/lib/chromium/chromium'
 ```
 
-The screen-share launcher favors responsiveness on the Raspberry Pi 3: it
-disables remote resizing, reduces Tight/JPEG quality, lowers compression work,
-and rate-limits pointer updates. WayVNC stays disabled between sessions; the
-launcher starts it before opening TigerVNC and stops it when the viewer exits.
-Set `REFLECTRUM_VNC_LOCAL_PORT` if port 5900 is already used locally.
+Direct DRM has no Wayland surface for WayVNC to capture. `pi:screenshare`
+therefore exits with an explanation while Cog is active. Use the Chromium
+fallback below when actual remote display capture is required; use `npm run dev`
+for routine UI work from the Mac.
 
 The live Motorola display identifies as `HDMI-A-1`, with a preferred mode of
-1366×768 at 60 Hz. After the 90-degree Wayland transform, applications see a
-768×1366 portrait workspace.
+1366×768 at 60 Hz. Cog's GLES rotation presents it as a 768×1366 portrait
+workspace.
 
 ## System settings
 
@@ -100,9 +102,27 @@ only POST `reboot` or `shutdown` to the loopback server. The tracked polkit rule
 allows the `pi` kiosk account only the matching logind power actions; it does not
 grant shell or general sudo access.
 
-Override the output, rotation, or URL by setting `REFLECTRUM_OUTPUT`,
-`REFLECTRUM_ROTATION`, or `REFLECTRUM_URL` in the graphical session before the
-autostart entry runs.
+Override the URL with `REFLECTRUM_URL` in `/etc/reflectrum/cog.env`.
+
+## Renderer recovery and comparison
+
+Chromium, LightDM, labwc, and the original graphical services remain installed
+as a recovery renderer. Switch away from Cog with:
+
+```sh
+sudo systemctl disable --now reflectrum-cog.service reflectrum-solaar-headless.service
+sudo systemctl enable --now lightdm.service
+```
+
+Return to the direct renderer with:
+
+```sh
+sudo systemctl disable --now lightdm.service
+sudo systemctl enable --now reflectrum-solaar-headless.service reflectrum-cog.service
+```
+
+Starting LightDM stops Cog because the units conflict. Re-enabling Cog stops the
+display manager and restores the headless Dialpad bridge.
 
 ## Night Shift
 
@@ -112,12 +132,14 @@ Install the Bookworm `wlsunset` package before the initial Reflectrum install:
 sudo apt install wlsunset
 ```
 
-The `reflectrum-night-shift` user service talks directly to labwc's
-`wlr-gamma-control` interface. It defaults to San Francisco (`37.8`, `-122.4`),
-6500 K during the day, and 4000 K at night. Solar elevation controls the smooth
-transition, so page changes and Chromium refreshes cannot interrupt the tint.
-The desktop autostart entry starts the service whenever the kiosk session logs
-in, including after a reboot.
+The `reflectrum-night-shift` user service is retained for the Chromium fallback
+and talks directly to labwc's `wlr-gamma-control` interface. It defaults to San
+Francisco (`37.8`, `-122.4`), 6500 K during the day, and 4000 K at night.
+
+Night Shift is unavailable in direct-DRM mode: Cog owns KMS and exposes neither
+a Wayland gamma-control protocol nor an external gamma interface. The service is
+therefore not started with Cog. This is an explicit performance tradeoff, not a
+browser overlay.
 
 Override the defaults in `/etc/reflectrum/night-shift.env`:
 
@@ -139,8 +161,9 @@ Useful diagnostics:
 
 ```sh
 systemctl status reflectrum-web
+journalctl -u reflectrum-cog --no-pager
+journalctl -u reflectrum-solaar-headless --no-pager
 journalctl -u reflectrum-web --no-pager
-wlr-randr
 curl --fail http://127.0.0.1:3000/
 ```
 
@@ -224,9 +247,8 @@ untracked `reflectrum-config.js`.
 ## Logitech MX Creative Dialpad
 
 Install Solaar 1.1.19 or newer before running the Reflectrum installer. Solaar
-translates the Dialpad's four HID++ buttons into ordinary keys that Chromium
-can receive; the wheels continue to use standard vertical and horizontal HID
-scroll events.
+translates the Dialpad's four HID++ buttons into ordinary keys that Reflectrum
+can receive.
 
 ```sh
 sudo apt install solaar
@@ -261,12 +283,13 @@ bluetoothctl devices Paired
 bluetoothctl info DEVICE_MAC
 ```
 
-Then load `http://127.0.0.1:3000/?input-debug=1` in Chromium and exercise every
-button, roller direction, dial direction, and dial press. The overlay shows the
-raw browser event and mapped Reflectrum command.
+Then temporarily set `REFLECTRUM_URL=http://127.0.0.1:3000/?input-debug=1` in
+`/etc/reflectrum/cog.env`, restart Cog, and exercise every button, roller
+direction, dial direction, and dial press. The overlay shows the raw browser
+event and mapped Reflectrum command.
 
-At graphical login, `reflectrum-mx-dialpad` starts Solaar, marks all four
-buttons as diverted, and applies these rules:
+The system-level headless listener marks all four buttons as diverted and
+applies these rules without GTK or a graphical login:
 
 | Dialpad control | Reflectrum action |
 | --- | --- |
@@ -275,11 +298,18 @@ buttons as diverted, and applies these rules:
 | Button 6 | Fade and toggle physical display power |
 | Left Scroll As Button 7 | Next item |
 
-The installer also adds Solaar's version-pinned `uinput` udev rule so these
-synthetic key events work under the Pi's Wayland session. Reboot after the
-first installation so the graphical session receives the new device ACLs.
+The large wheel reports horizontal high-resolution mouse-wheel events. Cog
+0.16's DRM input back end loses one direction, so the headless bridge grabs only
+the `MX Dialpad Mouse` event device and emits debounced Up/Down keys for both
+signs. The smaller bottom-right control remains mapped to Next item.
 
-If a control does not reach Chromium, inspect the Linux input layer:
+The installer also adds a version-pinned `uinput` udev rule. It grants the
+dedicated service's `input` group read/write access to Logitech `hidraw` devices
+and `/dev/uinput`. Members of that group can observe Logitech raw events and
+inject system-wide input, so this configuration is appropriate only for the
+dedicated, trusted mirror account. The service runs as `pi`, not root.
+
+If a control does not reach Reflectrum, inspect the Linux input layer:
 
 ```sh
 sudo libinput debug-events
@@ -287,15 +317,16 @@ sudo evtest
 ```
 
 Solaar handles the vendor HID++ buttons outside the browser, avoiding WebHID's
-interactive permission prompt. Reflectrum itself remains device-independent.
+interactive permission prompt. Fixed Linux key codes replace Solaar's GTK key
+map in headless mode. Reflectrum itself remains device-independent.
 
 Button 6 emits `F13`, which Reflectrum reserves for display power. The app fades
-to black before asking the loopback service to disable the live Wayland output,
-and enables HDMI with its 90-degree transform before revealing the UI. Older
-non-Wayland Pi images fall back to `vcgencmd`. Other navigation input is ignored
-while the display is off. Override the defaults with
-`REFLECTRUM_DISPLAY_OUTPUT` and `REFLECTRUM_DISPLAY_ROTATION` in a service
-environment file. Test the service directly with:
+to an opaque black curtain and restores the UI with a short fade. That curtain
+is the effective mirror mode under full-KMS Cog because the Pi firmware ignores
+legacy `vcgencmd display_power` DPMS requests while Cog owns DRM. The Chromium
+fallback additionally powers the Wayland output through `wlr-randr`. Other
+navigation input is ignored while the curtain is active. Test the service
+directly with:
 
 ```sh
 curl http://127.0.0.1:3000/api/display

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -6,6 +6,9 @@ Reflectrum coexists with the FlightAware feeder:
 - `reflectrum-web.service` serves the static build on loopback port 3000.
 - the desktop autostart entry rotates `HDMI-A-1` 90 degrees with `wlr-randr`
   and opens Chromium in kiosk mode.
+- Pi 3 hardware automatically uses a low-overhead Chromium profile and skips
+  snapshot-based page transitions.
+- compressed RAM swap replaces the SD-card swap file.
 - `wlsunset` adjusts display color temperature through labwc's Wayland gamma
   controls; Night Shift is not rendered inside Chromium.
 
@@ -42,6 +45,29 @@ DHCP address changes do not require script updates. Override it with
 `REFLECTRUM_PI_HOST`. Deployment intentionally leaves
 `/opt/reflectrum/reflectrum-config.js` and `/etc/reflectrum/calendar.env`
 untouched.
+
+The performance setup launches Chromium's native binary directly under Wayland,
+avoiding the desktop wrapper's accessibility and extension flags. On a Pi 3 it
+also caps renderer processes and adds `performance=low` to the kiosk URL.
+Override automatic detection with `REFLECTRUM_PERFORMANCE_MODE=normal` or `low`
+in `/etc/reflectrum/kiosk.env`.
+
+`reflectrum-zram.service` allocates 50% of physical RAM as fast compressed swap
+and disables `dphys-swapfile`; the existing `/var/swap` file is left intact for
+easy rollback. Optional settings belong in `/etc/reflectrum/zram.env`:
+
+```ini
+REFLECTRUM_ZRAM_PERCENT=50
+REFLECTRUM_ZRAM_ALGORITHM=lz4
+```
+
+Verify the active swap and lean browser command with:
+
+```sh
+swapon --show
+systemctl status reflectrum-zram
+pgrep -af /usr/lib/chromium/chromium
+```
 
 The screen-share launcher favors responsiveness on the Raspberry Pi 3: it
 disables remote resizing, reduces Tight/JPEG quality, lowers compression work,

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -15,7 +15,7 @@ if [[ ! -f $source_dir/index.html ]]; then
   exit 1
 fi
 
-for command in chromium curl mkswap python3 solaar swapon swapoff wlr-randr wlsunset; do
+for command in chromium cog curl mkswap python3 setfacl solaar swapon swapoff wlr-randr wlsunset; do
   command -v "$command" >/dev/null 2>&1 || {
     echo "Required command is missing: $command" >&2
     exit 1
@@ -37,6 +37,12 @@ install -o root -g root -m 0644 \
 install -o root -g root -m 0755 \
   "$repo_root/deploy/reflectrum-kiosk" \
   /usr/local/bin/reflectrum-kiosk
+install -o root -g root -m 0755 \
+  "$repo_root/deploy/reflectrum-cog" \
+  /usr/local/bin/reflectrum-cog
+install -o root -g root -m 0644 \
+  "$repo_root/deploy/reflectrum-cog.service" \
+  /etc/systemd/system/reflectrum-cog.service
 install -o root -g root -m 0755 \
   "$repo_root/deploy/reflectrum-zram" \
   /usr/local/sbin/reflectrum-zram
@@ -67,6 +73,12 @@ install -o root -g root -m 0755 \
 install -o root -g root -m 0644 \
   "$repo_root/deploy/reflectrum-mx-dialpad.desktop" \
   /etc/xdg/autostart/reflectrum-mx-dialpad.desktop
+install -o root -g root -m 0755 \
+  "$repo_root/deploy/reflectrum_solaar_headless.py" \
+  /usr/local/lib/reflectrum/reflectrum_solaar_headless.py
+install -o root -g root -m 0644 \
+  "$repo_root/deploy/reflectrum-solaar-headless.service" \
+  /etc/systemd/system/reflectrum-solaar-headless.service
 
 install -d -o pi -g pi -m 0755 /home/pi/.config/solaar
 install -o pi -g pi -m 0644 \
@@ -80,9 +92,15 @@ install -o root -g root -m 0644 \
   /etc/polkit-1/rules.d/50-reflectrum-power.rules
 udevadm control --reload-rules
 modprobe uinput
+udevadm trigger --subsystem-match=misc --action=change
+udevadm trigger --subsystem-match=hidraw --action=change
+setfacl --remove-all /dev/uinput
+chgrp input /dev/uinput
+chmod 0660 /dev/uinput
 
 systemctl daemon-reload
-systemctl enable --now reflectrum-zram.service
+systemctl reenable reflectrum-zram.service
+systemctl restart reflectrum-zram.service
 sysctl -p /etc/sysctl.d/99-reflectrum-zram.conf
 if systemctl list-unit-files dphys-swapfile.service >/dev/null 2>&1; then
   systemctl disable --now dphys-swapfile.service
@@ -90,9 +108,11 @@ fi
 systemctl --global enable reflectrum-kiosk.service
 systemctl --global enable reflectrum-night-shift.service
 systemctl enable --now reflectrum-web.service
+systemctl disable lightdm.service
+systemctl enable --now reflectrum-solaar-headless.service reflectrum-cog.service
 
 if command -v raspi-config >/dev/null 2>&1; then
   raspi-config nonint do_blanking 1
 fi
 
-echo 'Reflectrum installed. Log out and back in, or reboot, to start kiosk mode.'
+echo 'Reflectrum installed with the Cog direct-DRM kiosk.'

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -15,7 +15,7 @@ if [[ ! -f $source_dir/index.html ]]; then
   exit 1
 fi
 
-for command in chromium curl python3 solaar wlr-randr wlsunset; do
+for command in chromium curl mkswap python3 solaar swapon swapoff wlr-randr wlsunset; do
   command -v "$command" >/dev/null 2>&1 || {
     echo "Required command is missing: $command" >&2
     exit 1
@@ -37,6 +37,15 @@ install -o root -g root -m 0644 \
 install -o root -g root -m 0755 \
   "$repo_root/deploy/reflectrum-kiosk" \
   /usr/local/bin/reflectrum-kiosk
+install -o root -g root -m 0755 \
+  "$repo_root/deploy/reflectrum-zram" \
+  /usr/local/sbin/reflectrum-zram
+install -o root -g root -m 0644 \
+  "$repo_root/deploy/reflectrum-zram.service" \
+  /etc/systemd/system/reflectrum-zram.service
+install -o root -g root -m 0644 \
+  "$repo_root/deploy/99-reflectrum-zram.conf" \
+  /etc/sysctl.d/99-reflectrum-zram.conf
 install -o root -g root -m 0644 \
   "$repo_root/deploy/reflectrum-kiosk.service" \
   /etc/systemd/user/reflectrum-kiosk.service
@@ -73,6 +82,11 @@ udevadm control --reload-rules
 modprobe uinput
 
 systemctl daemon-reload
+systemctl enable --now reflectrum-zram.service
+sysctl -p /etc/sysctl.d/99-reflectrum-zram.conf
+if systemctl list-unit-files dphys-swapfile.service >/dev/null 2>&1; then
+  systemctl disable --now dphys-swapfile.service
+fi
 systemctl --global enable reflectrum-kiosk.service
 systemctl --global enable reflectrum-night-shift.service
 systemctl enable --now reflectrum-web.service

--- a/deploy/reflectrum-cog
+++ b/deploy/reflectrum-cog
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -eu
+
+url=${REFLECTRUM_URL:-http://127.0.0.1:3000/}
+video_mode=${REFLECTRUM_COG_VIDEO_MODE:-1366x768}
+rotation=${REFLECTRUM_COG_ROTATION:-3}
+device_scale=${REFLECTRUM_DEVICE_SCALE_FACTOR:-1}
+memory_limit=${REFLECTRUM_COG_MEMORY_LIMIT:-512}
+
+case "$url" in
+  *performance=low*) ;;
+  *\?*) url="${url}&performance=low" ;;
+  *) url="${url}?performance=low" ;;
+esac
+
+attempt=0
+until curl --fail --silent --output /dev/null "$url"; do
+  attempt=$((attempt + 1))
+  if [ "$attempt" -ge 60 ]; then
+    logger -t reflectrum "web application did not become ready at $url"
+    exit 1
+  fi
+  sleep 1
+done
+
+export COG_PLATFORM_DRM_VIDEO_MODE="$video_mode"
+export COG_PLATFORM_DRM_CURSOR=0
+
+exec cog \
+  --platform=drm \
+  --platform-params="renderer=gles,rotation=$rotation" \
+  --device-scale="$device_scale" \
+  --bg-color=black \
+  --webprocess-failure=restart \
+  --enable-accelerated-2d-canvas=true \
+  --enable-smooth-scrolling=false \
+  --web-mem-limit="$memory_limit" \
+  "$url"

--- a/deploy/reflectrum-cog.service
+++ b/deploy/reflectrum-cog.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Reflectrum Cog direct-DRM kiosk
+After=reflectrum-web.service reflectrum-solaar-headless.service
+Wants=reflectrum-web.service reflectrum-solaar-headless.service
+Conflicts=display-manager.service
+Before=display-manager.service
+
+[Service]
+Type=simple
+User=pi
+Group=pi
+SupplementaryGroups=video render input
+Environment=HOME=/home/pi
+EnvironmentFile=-/etc/reflectrum/cog.env
+ExecStart=/usr/local/bin/reflectrum-cog
+Restart=on-failure
+RestartSec=3
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/reflectrum-kiosk
+++ b/deploy/reflectrum-kiosk
@@ -7,6 +7,8 @@ url=${REFLECTRUM_URL:-http://127.0.0.1:3000/}
 performance_mode=${REFLECTRUM_PERFORMANCE_MODE:-auto}
 ozone_platform=${REFLECTRUM_OZONE_PLATFORM:-auto}
 display_mode=${REFLECTRUM_DISPLAY_MODE:-auto}
+display_mode_kind=${REFLECTRUM_DISPLAY_MODE_KIND:-auto}
+device_scale_factor=${REFLECTRUM_DEVICE_SCALE_FACTOR:-auto}
 
 if [ "$performance_mode" = auto ] && [ -r /proc/device-tree/model ]; then
   case "$(tr -d '\000' < /proc/device-tree/model)" in
@@ -24,10 +26,22 @@ fi
 
 if [ "$display_mode" = auto ]; then
   if [ "$performance_mode" = low ]; then
-    display_mode=720x480@60Hz
+    display_mode=854x480@60Hz
+    if [ "$display_mode_kind" = auto ]; then
+      display_mode_kind=custom
+    fi
+    if [ "$device_scale_factor" = auto ]; then
+      device_scale_factor=0.625
+    fi
   else
     display_mode=
   fi
+fi
+if [ "$display_mode_kind" = auto ]; then
+  display_mode_kind=standard
+fi
+if [ "$device_scale_factor" = auto ]; then
+  device_scale_factor=
 fi
 
 if [ "$performance_mode" = low ]; then
@@ -40,7 +54,11 @@ fi
 
 if command -v wlr-randr >/dev/null 2>&1; then
   if [ -n "$display_mode" ]; then
-    if ! wlr-randr --output "$output" --mode "$display_mode" --transform "$rotation"; then
+    mode_option=--mode
+    if [ "$display_mode_kind" = custom ]; then
+      mode_option=--custom-mode
+    fi
+    if ! wlr-randr --output "$output" "$mode_option" "$display_mode" --transform "$rotation"; then
       logger -t reflectrum "could not set $output to $display_mode at $rotation degrees"
     fi
   elif ! wlr-randr --output "$output" --transform "$rotation"; then
@@ -99,6 +117,10 @@ fi
 
 if [ "$performance_mode" = low ]; then
   set -- "$@" --enable-low-end-device-mode --renderer-process-limit=2
+fi
+
+if [ -n "$device_scale_factor" ]; then
+  set -- "$@" --force-device-scale-factor="$device_scale_factor"
 fi
 
 exec "$browser" "$@"

--- a/deploy/reflectrum-kiosk
+++ b/deploy/reflectrum-kiosk
@@ -5,11 +5,20 @@ output=${REFLECTRUM_OUTPUT:-HDMI-A-1}
 rotation=${REFLECTRUM_ROTATION:-90}
 url=${REFLECTRUM_URL:-http://127.0.0.1:3000/}
 performance_mode=${REFLECTRUM_PERFORMANCE_MODE:-auto}
+ozone_platform=${REFLECTRUM_OZONE_PLATFORM:-auto}
 
 if [ "$performance_mode" = auto ] && [ -r /proc/device-tree/model ]; then
   case "$(tr -d '\000' < /proc/device-tree/model)" in
     *"Raspberry Pi 3"*) performance_mode=low ;;
   esac
+fi
+
+if [ "$ozone_platform" = auto ]; then
+  if [ "$performance_mode" = low ]; then
+    ozone_platform=x11
+  else
+    ozone_platform=wayland
+  fi
 fi
 
 if [ "$performance_mode" = low ]; then
@@ -72,7 +81,7 @@ set -- \
   --user-data-dir="$HOME/.config/reflectrum-chromium"
 
 if [ -n "${WAYLAND_DISPLAY:-}" ]; then
-  set -- "$@" --ozone-platform=wayland
+  set -- "$@" --ozone-platform="$ozone_platform"
 fi
 
 if [ "$performance_mode" = low ]; then

--- a/deploy/reflectrum-kiosk
+++ b/deploy/reflectrum-kiosk
@@ -6,6 +6,7 @@ rotation=${REFLECTRUM_ROTATION:-90}
 url=${REFLECTRUM_URL:-http://127.0.0.1:3000/}
 performance_mode=${REFLECTRUM_PERFORMANCE_MODE:-auto}
 ozone_platform=${REFLECTRUM_OZONE_PLATFORM:-auto}
+display_mode=${REFLECTRUM_DISPLAY_MODE:-auto}
 
 if [ "$performance_mode" = auto ] && [ -r /proc/device-tree/model ]; then
   case "$(tr -d '\000' < /proc/device-tree/model)" in
@@ -21,6 +22,14 @@ if [ "$ozone_platform" = auto ]; then
   fi
 fi
 
+if [ "$display_mode" = auto ]; then
+  if [ "$performance_mode" = low ]; then
+    display_mode=720x480@60Hz
+  else
+    display_mode=
+  fi
+fi
+
 if [ "$performance_mode" = low ]; then
   case "$url" in
     *performance=low*) ;;
@@ -30,7 +39,11 @@ if [ "$performance_mode" = low ]; then
 fi
 
 if command -v wlr-randr >/dev/null 2>&1; then
-  if ! wlr-randr --output "$output" --transform "$rotation"; then
+  if [ -n "$display_mode" ]; then
+    if ! wlr-randr --output "$output" --mode "$display_mode" --transform "$rotation"; then
+      logger -t reflectrum "could not set $output to $display_mode at $rotation degrees"
+    fi
+  elif ! wlr-randr --output "$output" --transform "$rotation"; then
     logger -t reflectrum "could not rotate $output to $rotation degrees"
   fi
 fi

--- a/deploy/reflectrum-kiosk
+++ b/deploy/reflectrum-kiosk
@@ -4,6 +4,21 @@ set -eu
 output=${REFLECTRUM_OUTPUT:-HDMI-A-1}
 rotation=${REFLECTRUM_ROTATION:-90}
 url=${REFLECTRUM_URL:-http://127.0.0.1:3000/}
+performance_mode=${REFLECTRUM_PERFORMANCE_MODE:-auto}
+
+if [ "$performance_mode" = auto ] && [ -r /proc/device-tree/model ]; then
+  case "$(tr -d '\000' < /proc/device-tree/model)" in
+    *"Raspberry Pi 3"*) performance_mode=low ;;
+  esac
+fi
+
+if [ "$performance_mode" = low ]; then
+  case "$url" in
+    *performance=low*) ;;
+    *\?*) url="${url}&performance=low" ;;
+    *) url="${url}?performance=low" ;;
+  esac
+fi
 
 if command -v wlr-randr >/dev/null 2>&1; then
   if ! wlr-randr --output "$output" --transform "$rotation"; then
@@ -21,19 +36,47 @@ until curl --fail --silent --output /dev/null "$url"; do
   sleep 1
 done
 
-browser=$(command -v chromium || command -v chromium-browser || true)
+browser=${REFLECTRUM_BROWSER:-}
+if [ -z "$browser" ] && [ -x /usr/lib/chromium/chromium ]; then
+  # Raspberry Pi OS wraps Chromium with desktop-oriented accessibility and
+  # extension flags. The kiosk does not need them, so use the binary directly.
+  browser=/usr/lib/chromium/chromium
+fi
+if [ -z "$browser" ]; then
+  browser=$(command -v chromium || command -v chromium-browser || true)
+fi
 if [ -z "$browser" ]; then
   logger -t reflectrum "Chromium is not installed"
   exit 1
 fi
 
-exec "$browser" \
+set -- \
   --app="$url" \
   --kiosk \
   --no-first-run \
+  --no-default-browser-check \
+  --noerrdialogs \
   --disable-infobars \
   --disable-session-crashed-bubble \
   --disable-pinch \
+  --disable-extensions \
+  --disable-component-update \
+  --disable-background-networking \
+  --disable-sync \
+  --disable-translate \
+  --disable-renderer-accessibility \
+  --enable-gpu-rasterization \
+  --use-angle=gles \
   --overscroll-history-navigation=0 \
   --password-store=basic \
   --user-data-dir="$HOME/.config/reflectrum-chromium"
+
+if [ -n "${WAYLAND_DISPLAY:-}" ]; then
+  set -- "$@" --ozone-platform=wayland
+fi
+
+if [ "$performance_mode" = low ]; then
+  set -- "$@" --enable-low-end-device-mode --renderer-process-limit=2
+fi
+
+exec "$browser" "$@"

--- a/deploy/reflectrum-solaar-headless.service
+++ b/deploy/reflectrum-solaar-headless.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Reflectrum Logitech button bridge
+After=bluetooth.target
+Wants=bluetooth.target
+PartOf=reflectrum-cog.service
+
+[Service]
+Type=simple
+User=pi
+Group=pi
+SupplementaryGroups=input
+Environment=HOME=/home/pi
+ExecStart=/usr/local/lib/reflectrum/reflectrum_solaar_headless.py
+Restart=on-failure
+RestartSec=2
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/reflectrum-zram
+++ b/deploy/reflectrum-zram
@@ -1,0 +1,63 @@
+#!/bin/sh
+set -eu
+
+device=/dev/zram0
+percent=${REFLECTRUM_ZRAM_PERCENT:-50}
+requested_algorithm=${REFLECTRUM_ZRAM_ALGORITHM:-auto}
+
+is_active() {
+  swapon --show=NAME --noheadings 2>/dev/null | grep -Fxq "$device"
+}
+
+start_zram() {
+  is_active && return 0
+
+  case "$percent" in
+    ''|*[!0-9]*) echo "Invalid REFLECTRUM_ZRAM_PERCENT: $percent" >&2; exit 1 ;;
+  esac
+  if [ "$percent" -lt 10 ] || [ "$percent" -gt 100 ]; then
+    echo 'REFLECTRUM_ZRAM_PERCENT must be between 10 and 100.' >&2
+    exit 1
+  fi
+
+  modprobe zram num_devices=1
+  echo 1 > /sys/block/zram0/reset
+
+  available=$(tr -d '[]' < /sys/block/zram0/comp_algorithm)
+  algorithm=$requested_algorithm
+  if [ "$algorithm" = auto ]; then
+    algorithm=
+    for candidate in lz4 lzo-rle zstd lzo; do
+      case " $available " in
+        *" $candidate "*) algorithm=$candidate; break ;;
+      esac
+    done
+  fi
+  case " $available " in
+    *" $algorithm "*) ;;
+    *) echo "Unsupported zram algorithm: $algorithm (available: $available)" >&2; exit 1 ;;
+  esac
+
+  memory_kib=$(awk '/^MemTotal:/ { print $2 }' /proc/meminfo)
+  size_bytes=$((memory_kib * 1024 * percent / 100))
+  echo "$algorithm" > /sys/block/zram0/comp_algorithm
+  echo "$size_bytes" > /sys/block/zram0/disksize
+  mkswap --label reflectrum-zram "$device" >/dev/null
+  swapon --priority 100 "$device"
+  logger -t reflectrum-zram "enabled $device at ${percent}% of RAM using $algorithm"
+}
+
+stop_zram() {
+  if is_active; then
+    swapoff "$device"
+  fi
+  if [ -w /sys/block/zram0/reset ]; then
+    echo 1 > /sys/block/zram0/reset
+  fi
+}
+
+case "${1:-start}" in
+  start) start_zram ;;
+  stop) stop_zram ;;
+  *) echo "Usage: $0 {start|stop}" >&2; exit 2 ;;
+esac

--- a/deploy/reflectrum-zram
+++ b/deploy/reflectrum-zram
@@ -21,7 +21,9 @@ start_zram() {
   fi
 
   modprobe zram num_devices=1
-  echo 1 > /sys/block/zram0/reset
+  if [ "$(cat /sys/block/zram0/disksize)" -ne 0 ]; then
+    echo 1 > /sys/block/zram0/reset
+  fi
 
   available=$(tr -d '[]' < /sys/block/zram0/comp_algorithm)
   algorithm=$requested_algorithm

--- a/deploy/reflectrum-zram.service
+++ b/deploy/reflectrum-zram.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Reflectrum compressed RAM swap
 After=systemd-modules-load.service local-fs.target
-Before=swap.target
 
 [Service]
 Type=oneshot
@@ -11,4 +10,4 @@ ExecStop=/usr/local/sbin/reflectrum-zram stop
 RemainAfterExit=yes
 
 [Install]
-WantedBy=swap.target
+WantedBy=multi-user.target

--- a/deploy/reflectrum-zram.service
+++ b/deploy/reflectrum-zram.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Reflectrum compressed RAM swap
+After=systemd-modules-load.service local-fs.target
+Before=swap.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/etc/reflectrum/zram.env
+ExecStart=/usr/local/sbin/reflectrum-zram start
+ExecStop=/usr/local/sbin/reflectrum-zram stop
+RemainAfterExit=yes
+
+[Install]
+WantedBy=swap.target

--- a/deploy/reflectrum_server.py
+++ b/deploy/reflectrum_server.py
@@ -344,15 +344,18 @@ class ReflectrumHandler(SimpleHTTPRequestHandler):
 
     def display_command(self, power=None):
         wayland_command = shutil.which("wlr-randr")
-        if wayland_command:
+        runtime_dir = os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+        wayland_display = os.environ.get("WAYLAND_DISPLAY", "wayland-0")
+        wayland_socket = os.path.join(runtime_dir, wayland_display)
+        if wayland_command and os.path.exists(wayland_socket):
             output_name = os.environ.get("REFLECTRUM_DISPLAY_OUTPUT", "HDMI-A-1")
             rotation = os.environ.get("REFLECTRUM_DISPLAY_ROTATION", "90")
             allowed_rotations = {"normal", "90", "180", "270", "flipped", "flipped-90", "flipped-180", "flipped-270"}
             if rotation not in allowed_rotations:
                 rotation = "90"
             environment = os.environ.copy()
-            environment.setdefault("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
-            environment.setdefault("WAYLAND_DISPLAY", "wayland-0")
+            environment.setdefault("XDG_RUNTIME_DIR", runtime_dir)
+            environment.setdefault("WAYLAND_DISPLAY", wayland_display)
             if power is not None:
                 command = [wayland_command, "--output", output_name, "--off"]
                 if power == "on":

--- a/deploy/reflectrum_solaar_headless.py
+++ b/deploy/reflectrum_solaar_headless.py
@@ -1,0 +1,140 @@
+#!/opt/pipx/venvs/solaar/bin/python
+"""Run Solaar's HID++ listener and diversion rules without its GTK UI."""
+
+from __future__ import annotations
+
+import logging
+import signal
+import threading
+import time
+
+from gi.repository import GLib
+from logitech_receiver import diversion
+from solaar import configuration, listener
+
+
+logging.basicConfig(
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    level=logging.INFO,
+)
+logger = logging.getLogger("reflectrum.solaar")
+loop = GLib.MainLoop()
+stopping = threading.Event()
+
+HEADLESS_KEY_CODES = {
+    "Escape": diversion.evdev.ecodes.KEY_ESC,
+    "Return": diversion.evdev.ecodes.KEY_ENTER,
+    "F13": diversion.evdev.ecodes.KEY_F13,
+    "Down": diversion.evdev.ecodes.KEY_DOWN,
+}
+
+
+def evaluate_keypress(self, feature, notification, device, last_result):
+    """Emit the small Reflectrum key set without a GTK/GDK key map."""
+    for key_name in self.key_names:
+        key_code = HEADLESS_KEY_CODES.get(key_name)
+        if key_code is None:
+            logger.warning("no headless key code configured for %s", key_name)
+            continue
+        if self.action != diversion.RELEASE:
+            diversion.simulate_uinput(diversion.evdev.ecodes.EV_KEY, key_code, 1)
+        if self.action != diversion.DEPRESS:
+            diversion.simulate_uinput(diversion.evdev.ecodes.EV_KEY, key_code, 0)
+    time.sleep(0.01)
+    return None
+
+
+def emit_key(key_code):
+    diversion.simulate_uinput(diversion.evdev.ecodes.EV_KEY, key_code, 1)
+    diversion.simulate_uinput(diversion.evdev.ecodes.EV_KEY, key_code, 0)
+
+
+def dial_wheel_loop():
+    """Translate the Dialpad's horizontal wheel around Cog 0.16's DRM bug."""
+    cooldown_seconds = 0.11
+    while not stopping.is_set():
+        dial = None
+        try:
+            for path in diversion.evdev.list_devices():
+                candidate = diversion.evdev.InputDevice(path)
+                if candidate.name == "MX Dialpad Mouse":
+                    dial = candidate
+                    break
+                candidate.close()
+
+            if dial is None:
+                stopping.wait(2)
+                continue
+
+            logger.info("capturing Dialpad wheel from %s", dial.path)
+            dial.grab()
+            last_action_at = 0.0
+            for event in dial.read_loop():
+                if stopping.is_set():
+                    break
+                if (
+                    event.type != diversion.evdev.ecodes.EV_REL
+                    or event.code != diversion.evdev.ecodes.REL_HWHEEL
+                    or event.value == 0
+                ):
+                    continue
+
+                now = time.monotonic()
+                if now - last_action_at < cooldown_seconds:
+                    continue
+                last_action_at = now
+                key_code = (
+                    diversion.evdev.ecodes.KEY_UP
+                    if event.value < 0
+                    else diversion.evdev.ecodes.KEY_DOWN
+                )
+                emit_key(key_code)
+        except OSError as error:
+            logger.warning("Dialpad wheel reader restarting: %s", error)
+            stopping.wait(2)
+        finally:
+            if dial is not None:
+                try:
+                    dial.ungrab()
+                except OSError:
+                    pass
+                dial.close()
+
+
+def status_changed(device, alert=None, reason=None, refresh=False):
+    logger.info("device status changed: %s (%s)", device, reason or "no reason")
+
+
+def setting_changed(device, setting_class, values):
+    logger.debug("setting changed for %s: %s=%s", device, setting_class, values)
+
+
+def error_callback(reason, path):
+    logger.error("Solaar device error for %s: %s", path, reason)
+
+
+def stop(_signum, _frame):
+    stopping.set()
+    loop.quit()
+
+
+def main():
+    signal.signal(signal.SIGINT, stop)
+    signal.signal(signal.SIGTERM, stop)
+
+    diversion.KeyPress.evaluate = evaluate_keypress
+    if not diversion.setup_uinput():
+        raise RuntimeError("Could not create the Solaar virtual keyboard")
+
+    threading.Thread(target=dial_wheel_loop, name="dial-wheel", daemon=True).start()
+    listener.setup_scanner(status_changed, setting_changed, error_callback)
+    configuration.defer_saves = True
+    listener.start_all()
+    try:
+        loop.run()
+    finally:
+        listener.stop_all()
+
+
+if __name__ == "__main__":
+    main()

--- a/public/reflectrum-config.js
+++ b/public/reflectrum-config.js
@@ -6,7 +6,7 @@ window.REFLECTRUM_CONFIG = {
   // homeAssistant: {
   //   historyEntities: ['sensor.outdoor_temperature', 'sensor.internet_download_speed'],
   // },
-  // performanceMode: 'low', // Disables snapshot-based page transitions.
+  // performanceMode: 'low', // Uses lower-overhead input and browser defaults.
   // pageTransitions: false,
   // inputDiagnostics: true,
   // input: {

--- a/public/reflectrum-config.js
+++ b/public/reflectrum-config.js
@@ -6,6 +6,8 @@ window.REFLECTRUM_CONFIG = {
   // homeAssistant: {
   //   historyEntities: ['sensor.outdoor_temperature', 'sensor.internet_download_speed'],
   // },
+  // performanceMode: 'low', // Disables snapshot-based page transitions.
+  // pageTransitions: false,
   // inputDiagnostics: true,
   // input: {
   //   keyMap: { F13: 'UP_CLICK', F14: 'DOWN_CLICK' },

--- a/scripts/pi-deploy
+++ b/scripts/pi-deploy
@@ -19,11 +19,16 @@ rsync -az --delete \
   deploy/reflectrum-night-shift.service \
   deploy/reflectrum-night-shift.desktop \
   deploy/reflectrum-kiosk \
+  deploy/reflectrum-cog \
+  deploy/reflectrum-cog.service \
   deploy/reflectrum-zram \
   deploy/reflectrum-zram.service \
   deploy/99-reflectrum-zram.conf \
   deploy/50-reflectrum-power.rules \
+  deploy/42-reflectrum-logitech-permissions.rules \
   deploy/reflectrum-solaar-rules.yaml \
+  deploy/reflectrum_solaar_headless.py \
+  deploy/reflectrum-solaar-headless.service \
   "$pi_host:$runtime_staging/"
 
 # Install only generated files. The Pi's deployment-local
@@ -37,15 +42,19 @@ ssh "$pi_host" "sudo install -o root -g root -m 0755 $runtime_staging/reflectrum
 ssh "$pi_host" "sudo install -o root -g root -m 0644 $runtime_staging/reflectrum-night-shift.service /etc/systemd/user/reflectrum-night-shift.service"
 ssh "$pi_host" "sudo install -o root -g root -m 0644 $runtime_staging/reflectrum-night-shift.desktop /etc/xdg/autostart/reflectrum-night-shift.desktop"
 ssh "$pi_host" "sudo install -o root -g root -m 0755 $runtime_staging/reflectrum-kiosk /usr/local/bin/reflectrum-kiosk"
+ssh "$pi_host" "sudo install -o root -g root -m 0755 $runtime_staging/reflectrum-cog /usr/local/bin/reflectrum-cog"
+ssh "$pi_host" "sudo install -o root -g root -m 0644 $runtime_staging/reflectrum-cog.service /etc/systemd/system/reflectrum-cog.service"
 ssh "$pi_host" "sudo install -o root -g root -m 0755 $runtime_staging/reflectrum-zram /usr/local/sbin/reflectrum-zram"
 ssh "$pi_host" "sudo install -o root -g root -m 0644 $runtime_staging/reflectrum-zram.service /etc/systemd/system/reflectrum-zram.service"
 ssh "$pi_host" "sudo install -o root -g root -m 0644 $runtime_staging/99-reflectrum-zram.conf /etc/sysctl.d/99-reflectrum-zram.conf"
 ssh "$pi_host" "sudo install -o root -g root -m 0644 $runtime_staging/50-reflectrum-power.rules /etc/polkit-1/rules.d/50-reflectrum-power.rules"
+ssh "$pi_host" "sudo install -o root -g root -m 0644 $runtime_staging/42-reflectrum-logitech-permissions.rules /etc/udev/rules.d/42-reflectrum-logitech-permissions.rules"
 ssh "$pi_host" "sudo install -o pi -g pi -m 0644 $runtime_staging/reflectrum-solaar-rules.yaml /home/pi/.config/solaar/rules.yaml"
-ssh "$pi_host" "sudo systemctl daemon-reload && sudo systemctl enable --now reflectrum-zram.service && sudo sysctl -p /etc/sysctl.d/99-reflectrum-zram.conf && if systemctl list-unit-files dphys-swapfile.service >/dev/null 2>&1; then sudo systemctl disable --now dphys-swapfile.service; fi && sudo systemctl --global enable reflectrum-night-shift.service && sudo systemctl restart reflectrum-web.service"
-ssh "$pi_host" "systemctl --user daemon-reload && systemctl --user enable --now reflectrum-night-shift.service"
+ssh "$pi_host" "sudo install -o root -g root -m 0755 $runtime_staging/reflectrum_solaar_headless.py /usr/local/lib/reflectrum/reflectrum_solaar_headless.py"
+ssh "$pi_host" "sudo install -o root -g root -m 0644 $runtime_staging/reflectrum-solaar-headless.service /etc/systemd/system/reflectrum-solaar-headless.service"
+ssh "$pi_host" "sudo udevadm control --reload-rules && sudo udevadm trigger --subsystem-match=misc --action=change && sudo udevadm trigger --subsystem-match=hidraw --action=change && sudo setfacl --remove-all /dev/uinput && sudo chgrp input /dev/uinput && sudo chmod 0660 /dev/uinput"
+ssh "$pi_host" "sudo systemctl daemon-reload && sudo systemctl reenable reflectrum-zram.service && sudo systemctl restart reflectrum-zram.service && sudo sysctl -p /etc/sysctl.d/99-reflectrum-zram.conf && if systemctl list-unit-files dphys-swapfile.service >/dev/null 2>&1; then sudo systemctl disable --now dphys-swapfile.service; fi && sudo systemctl --global enable reflectrum-night-shift.service && sudo systemctl restart reflectrum-web.service && sudo systemctl disable lightdm.service && sudo systemctl enable --now reflectrum-solaar-headless.service reflectrum-cog.service"
 
 "$script_dir/pi-refresh"
 
 printf '%s\n' 'Reflectrum built, deployed, and refreshed.'
-printf '%s\n' 'Reboot once after changing Dialpad rules so the running Solaar session reloads them.'

--- a/scripts/pi-deploy
+++ b/scripts/pi-deploy
@@ -18,6 +18,10 @@ rsync -az --delete \
   deploy/reflectrum-night-shift \
   deploy/reflectrum-night-shift.service \
   deploy/reflectrum-night-shift.desktop \
+  deploy/reflectrum-kiosk \
+  deploy/reflectrum-zram \
+  deploy/reflectrum-zram.service \
+  deploy/99-reflectrum-zram.conf \
   deploy/50-reflectrum-power.rules \
   deploy/reflectrum-solaar-rules.yaml \
   "$pi_host:$runtime_staging/"
@@ -32,9 +36,13 @@ ssh "$pi_host" "sudo install -o root -g root -m 0644 $runtime_staging/reflectrum
 ssh "$pi_host" "sudo install -o root -g root -m 0755 $runtime_staging/reflectrum-night-shift /usr/local/bin/reflectrum-night-shift"
 ssh "$pi_host" "sudo install -o root -g root -m 0644 $runtime_staging/reflectrum-night-shift.service /etc/systemd/user/reflectrum-night-shift.service"
 ssh "$pi_host" "sudo install -o root -g root -m 0644 $runtime_staging/reflectrum-night-shift.desktop /etc/xdg/autostart/reflectrum-night-shift.desktop"
+ssh "$pi_host" "sudo install -o root -g root -m 0755 $runtime_staging/reflectrum-kiosk /usr/local/bin/reflectrum-kiosk"
+ssh "$pi_host" "sudo install -o root -g root -m 0755 $runtime_staging/reflectrum-zram /usr/local/sbin/reflectrum-zram"
+ssh "$pi_host" "sudo install -o root -g root -m 0644 $runtime_staging/reflectrum-zram.service /etc/systemd/system/reflectrum-zram.service"
+ssh "$pi_host" "sudo install -o root -g root -m 0644 $runtime_staging/99-reflectrum-zram.conf /etc/sysctl.d/99-reflectrum-zram.conf"
 ssh "$pi_host" "sudo install -o root -g root -m 0644 $runtime_staging/50-reflectrum-power.rules /etc/polkit-1/rules.d/50-reflectrum-power.rules"
 ssh "$pi_host" "sudo install -o pi -g pi -m 0644 $runtime_staging/reflectrum-solaar-rules.yaml /home/pi/.config/solaar/rules.yaml"
-ssh "$pi_host" "sudo systemctl daemon-reload && sudo systemctl --global enable reflectrum-night-shift.service && sudo systemctl restart reflectrum-web.service"
+ssh "$pi_host" "sudo systemctl daemon-reload && sudo systemctl enable --now reflectrum-zram.service && sudo sysctl -p /etc/sysctl.d/99-reflectrum-zram.conf && if systemctl list-unit-files dphys-swapfile.service >/dev/null 2>&1; then sudo systemctl disable --now dphys-swapfile.service; fi && sudo systemctl --global enable reflectrum-night-shift.service && sudo systemctl restart reflectrum-web.service"
 ssh "$pi_host" "systemctl --user daemon-reload && systemctl --user enable --now reflectrum-night-shift.service"
 
 "$script_dir/pi-refresh"

--- a/scripts/pi-refresh
+++ b/scripts/pi-refresh
@@ -3,7 +3,11 @@ set -eu
 
 pi_host=${REFLECTRUM_PI_HOST:-adsb.local}
 
-if ssh "$pi_host" "systemctl --user --machine=pi@ --quiet is-active reflectrum-kiosk.service"; then
+if ssh "$pi_host" "systemctl --quiet is-active reflectrum-cog.service"; then
+  ssh "$pi_host" "sudo systemctl restart reflectrum-solaar-headless.service reflectrum-cog.service"
+  printf 'Restarted Reflectrum Cog and input bridge on %s.\n' "$pi_host"
+  exit 0
+elif ssh "$pi_host" "systemctl --user --machine=pi@ --quiet is-active reflectrum-kiosk.service"; then
   kiosk_unit=reflectrum-kiosk.service
 elif ssh "$pi_host" "systemctl --user --machine=pi@ --quiet is-active reflectrum-kiosk-sf.service"; then
   kiosk_unit=reflectrum-kiosk-sf.service

--- a/scripts/pi-screenshare
+++ b/scripts/pi-screenshare
@@ -6,6 +6,16 @@ local_port=${REFLECTRUM_VNC_LOCAL_PORT:-5900}
 viewer=${REFLECTRUM_VNC_VIEWER:-/Applications/TigerVNC.app/Contents/MacOS/vncviewer}
 keychain_service=${REFLECTRUM_VNC_KEYCHAIN_SERVICE:-com.reflectrum.screenshare}
 VNC_USERNAME=${VNC_USERNAME:-reflectrum}
+vnc_started=false
+
+stop_vnc() {
+  if [ "$vnc_started" = true ]; then
+    ssh -o BatchMode=yes "$pi_host" \
+      'sudo systemctl stop wayvnc.service wayvnc-control.service' \
+      >/dev/null 2>&1 || true
+  fi
+}
+trap stop_vnc EXIT HUP INT TERM
 
 if [ ! -x "$viewer" ]; then
   printf '%s\n' 'TigerVNC is not installed in /Applications.' >&2
@@ -25,6 +35,10 @@ if [ -z "${VNC_PASSWORD:-}" ]; then
 fi
 export VNC_USERNAME VNC_PASSWORD
 
+ssh -o BatchMode=yes "$pi_host" \
+  'sudo systemctl start wayvnc-control.service wayvnc.service'
+vnc_started=true
+
 if ! nc -z 127.0.0.1 "$local_port" >/dev/null 2>&1; then
   ssh -f -N -T \
     -o BatchMode=yes \
@@ -37,7 +51,7 @@ fi
 
 # Tight encoding keeps text sharp while the lower JPEG quality and compression
 # levels reduce work on the Pi 3. The SSH tunnel continues to protect traffic.
-exec "$viewer" \
+"$viewer" \
   -RemoteResize=0 \
   -PreferredEncoding=Tight \
   -QualityLevel=5 \

--- a/scripts/pi-screenshare
+++ b/scripts/pi-screenshare
@@ -8,6 +8,14 @@ keychain_service=${REFLECTRUM_VNC_KEYCHAIN_SERVICE:-com.reflectrum.screenshare}
 VNC_USERNAME=${VNC_USERNAME:-reflectrum}
 vnc_started=false
 
+if ssh -o BatchMode=yes "$pi_host" \
+  'systemctl --quiet is-active reflectrum-cog.service'; then
+  printf '%s\n' \
+    'Screen sharing is unavailable while Cog owns the display through DRM.' \
+    'Use the documented Chromium fallback before starting WayVNC.' >&2
+  exit 1
+fi
+
 stop_vnc() {
   if [ "$vnc_started" = true ]; then
     ssh -o BatchMode=yes "$pi_host" \

--- a/scripts/pi-screenshare-setup
+++ b/scripts/pi-screenshare-setup
@@ -46,10 +46,12 @@ if ! printf '%s\n' "$new_password" | ssh -o BatchMode=yes "$pi_host" '
      ! systemctl is-active --quiet wayvnc.service; then
     sudo cp --preserve=mode,ownership "$rollback" "$config"
     sudo systemctl restart wayvnc.service
+    sudo systemctl stop wayvnc.service wayvnc-control.service
     exit 1
   fi
 
   test "$(sudo awk -F= '\''$1 == "address" { print $2 }'\'' "$config")" = 127.0.0.1
+  sudo systemctl stop wayvnc.service wayvnc-control.service
 '; then
   if [ "$had_old_password" = true ]; then
     security add-generic-password \
@@ -68,4 +70,5 @@ if ! printf '%s\n' "$new_password" | ssh -o BatchMode=yes "$pi_host" '
 fi
 
 printf '%s\n' \
-  'Reflectrum screen-share authentication is synchronized with macOS Keychain.'
+  'Reflectrum screen-share authentication is synchronized with macOS Keychain.' \
+  'WayVNC remains stopped and will start only for a screen-share session.'

--- a/src/components/ViewStack.jsx
+++ b/src/components/ViewStack.jsx
@@ -10,8 +10,6 @@ class ViewStack extends Component {
   render() {
     const activePageName = this.props.activePageName
 
-    console.log("ViewStack", pages, activePageName)
-
     return (
       <div className="view-stack">
         <div className="view-stack__page">

--- a/src/components/menu/Menu.css
+++ b/src/components/menu/Menu.css
@@ -45,11 +45,6 @@ body > div {
   will-change: transform;
 }
 
-html[data-performance-mode='low'] .menu-list-select-item {
-  transition-duration: 55ms;
-  will-change: auto;
-}
-
 .menu-list-item {
   height: var(--menu-item-height);
   color: white;

--- a/src/components/menu/Menu.css
+++ b/src/components/menu/Menu.css
@@ -45,6 +45,11 @@ body > div {
   will-change: transform;
 }
 
+html[data-performance-mode='low'] .menu-list-select-item {
+  transition-duration: 55ms;
+  will-change: auto;
+}
+
 .menu-list-item {
   height: var(--menu-item-height);
   color: white;

--- a/src/components/menu/Menu.css
+++ b/src/components/menu/Menu.css
@@ -45,6 +45,10 @@ body > div {
   will-change: transform;
 }
 
+html[data-performance-mode='low'] .menu-list-select-item {
+  transition-duration: 100ms;
+}
+
 .menu-list-item {
   height: var(--menu-item-height);
   color: white;

--- a/src/helpers/events.jsx
+++ b/src/helpers/events.jsx
@@ -15,7 +15,7 @@ const wheelConfig = {
   invert: inputConfig.invertWheel ?? false,
 };
 const wheelCooldownMs = inputConfig.wheelCooldownMs
-  ?? (resolvePerformanceMode() === 'low' ? 40 : 90);
+  ?? (resolvePerformanceMode() === 'low' ? 110 : 90);
 const pressState = { primary: false, secondary: false };
 let lastWheelActionAt = 0;
 let navigationInputBlocked = false;

--- a/src/helpers/events.jsx
+++ b/src/helpers/events.jsx
@@ -4,6 +4,7 @@ import {
   resolveMouseAction,
   resolveWheelAction,
 } from './inputMapping.js';
+import { resolvePerformanceMode } from './performanceMode.js';
 
 export const MirrorEvents = new EventEmitter();
 
@@ -13,7 +14,8 @@ const wheelConfig = {
   threshold: inputConfig.wheelThreshold ?? 1,
   invert: inputConfig.invertWheel ?? false,
 };
-const wheelCooldownMs = inputConfig.wheelCooldownMs ?? 90;
+const wheelCooldownMs = inputConfig.wheelCooldownMs
+  ?? (resolvePerformanceMode() === 'low' ? 40 : 90);
 const pressState = { primary: false, secondary: false };
 let lastWheelActionAt = 0;
 let navigationInputBlocked = false;

--- a/src/helpers/pageTransitions.js
+++ b/src/helpers/pageTransitions.js
@@ -1,4 +1,5 @@
 import { flushSync } from 'react-dom';
+import { resolvePerformanceMode } from './performanceMode.js';
 
 let activeTransition = null;
 
@@ -16,10 +17,8 @@ export const pageTransitionsAvailable = ({
   config = globalThis.REFLECTRUM_CONFIG,
   matchMedia = globalThis.matchMedia,
 } = {}) => {
-  if (config?.pageTransitions === false || config?.performanceMode === 'low') return false;
-
-  const search = new URLSearchParams(currentLocation?.search || '');
-  if (search.get('performance') === 'low') return false;
+  if (config?.pageTransitions === false) return false;
+  if (resolvePerformanceMode({ config, search: currentLocation?.search }) === 'low') return false;
   if (typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches) return false;
 
   return typeof currentDocument?.startViewTransition === 'function';

--- a/src/helpers/pageTransitions.js
+++ b/src/helpers/pageTransitions.js
@@ -10,9 +10,24 @@ export const navigationDirection = (action, state) => {
   return null;
 };
 
+export const pageTransitionsAvailable = ({
+  document: currentDocument = globalThis.document,
+  location: currentLocation = globalThis.location,
+  config = globalThis.REFLECTRUM_CONFIG,
+  matchMedia = globalThis.matchMedia,
+} = {}) => {
+  if (config?.pageTransitions === false || config?.performanceMode === 'low') return false;
+
+  const search = new URLSearchParams(currentLocation?.search || '');
+  if (search.get('performance') === 'low') return false;
+  if (typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches) return false;
+
+  return typeof currentDocument?.startViewTransition === 'function';
+};
+
 export const pageTransitionMiddleware = ({ getState }) => (next) => (action) => {
   const direction = navigationDirection(action, getState());
-  if (!direction || typeof document === 'undefined' || typeof document.startViewTransition !== 'function') {
+  if (!direction || !pageTransitionsAvailable()) {
     return next(action);
   }
 

--- a/src/helpers/pageTransitions.js
+++ b/src/helpers/pageTransitions.js
@@ -1,5 +1,4 @@
 import { flushSync } from 'react-dom';
-import { resolvePerformanceMode } from './performanceMode.js';
 
 let activeTransition = null;
 
@@ -18,7 +17,6 @@ export const pageTransitionsAvailable = ({
   matchMedia = globalThis.matchMedia,
 } = {}) => {
   if (config?.pageTransitions === false) return false;
-  if (resolvePerformanceMode({ config, search: currentLocation?.search }) === 'low') return false;
   if (typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches) return false;
 
   return typeof currentDocument?.startViewTransition === 'function';

--- a/src/helpers/performanceMode.js
+++ b/src/helpers/performanceMode.js
@@ -1,0 +1,10 @@
+export const resolvePerformanceMode = ({
+  config = globalThis.REFLECTRUM_CONFIG,
+  search = globalThis.location?.search,
+} = {}) => {
+  if (config?.performanceMode === 'low' || config?.performanceMode === 'normal') {
+    return config.performanceMode;
+  }
+
+  return new URLSearchParams(search || '').get('performance') === 'low' ? 'low' : 'normal';
+};

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,6 +7,7 @@ import InputDiagnostics from './components/InputDiagnostics.jsx';
 import { mainMenu } from './components/MainMenu.jsx';
 import moment from 'moment';
 import { pageTransitionMiddleware } from './helpers/pageTransitions.js';
+import { resolvePerformanceMode } from './helpers/performanceMode.js';
 import './base.css';
 
 
@@ -20,6 +21,7 @@ import './base.css';
 //VEC: Additional Pages API
 
 const runtimeConfig = window.REFLECTRUM_CONFIG || {};
+document.documentElement.dataset.performanceMode = resolvePerformanceMode({ config: runtimeConfig });
 
 if (!localStorage.getItem('username')) {
   localStorage.setItem('username', runtimeConfig.username || 'Mirror');
@@ -69,8 +71,6 @@ const reflectrumApp = (state = data, action) => {
     case 'OPEN_ITEM':
       if (!!action.page && state.standby === false) {
         var newHistory = [...state.history, action.page]
-        console.log("OPEN_ITEM: ", newHistory, action.page)
-
         return Object.assign({}, state, {
           activePageName: action.page,
           history: newHistory,
@@ -99,7 +99,6 @@ const reflectrumApp = (state = data, action) => {
         var newHistory = [...state.history];
         newHistory.pop();
 
-        console.log("BACK: ", newHistory);
         return Object.assign({}, state, {
           activePageName: newHistory[newHistory.length - 1],
           history: newHistory,
@@ -111,7 +110,6 @@ const reflectrumApp = (state = data, action) => {
 
       break;
     case 'SCROLL_DOWN':
-      console.log("SCROLL_DOWN", state, action);
       if (state.selectedItem !== action.MAX && state.standby === false) {
         return Object.assign({}, state, {
           selectedItem: state.selectedItem + 1,
@@ -145,7 +143,6 @@ const reflectrumApp = (state = data, action) => {
       });
       break;
     case 'STANDBY':
-      console.log("STATE", state, action);
       if (action.standby === false) {
         return Object.assign({}, state, {
           standby: action.standby,

--- a/test/pageTransitions.test.js
+++ b/test/pageTransitions.test.js
@@ -26,11 +26,9 @@ test('does not transition unrelated or standby actions', () => {
   assert.equal(navigationDirection({ type: 'OPEN_ITEM', page: 'WEATHER' }, { ...state, standby: true }), null);
 });
 
-test('disables snapshot transitions in low-performance deployments', () => {
+test('allows deployments to explicitly disable snapshot transitions', () => {
   const document = { startViewTransition() {} };
 
-  assert.equal(pageTransitionsAvailable({ document, location: { search: '?performance=low' } }), false);
-  assert.equal(pageTransitionsAvailable({ document, config: { performanceMode: 'low' } }), false);
   assert.equal(pageTransitionsAvailable({ document, config: { pageTransitions: false } }), false);
 });
 

--- a/test/pageTransitions.test.js
+++ b/test/pageTransitions.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   navigationDirection,
+  pageTransitionsAvailable,
   pageTransitionMiddleware,
 } from '../src/helpers/pageTransitions.js';
 
@@ -23,6 +24,21 @@ test('marks back navigation as pop only when history can pop', () => {
 test('does not transition unrelated or standby actions', () => {
   assert.equal(navigationDirection({ type: 'SCROLL_DOWN' }, state), null);
   assert.equal(navigationDirection({ type: 'OPEN_ITEM', page: 'WEATHER' }, { ...state, standby: true }), null);
+});
+
+test('disables snapshot transitions in low-performance deployments', () => {
+  const document = { startViewTransition() {} };
+
+  assert.equal(pageTransitionsAvailable({ document, location: { search: '?performance=low' } }), false);
+  assert.equal(pageTransitionsAvailable({ document, config: { performanceMode: 'low' } }), false);
+  assert.equal(pageTransitionsAvailable({ document, config: { pageTransitions: false } }), false);
+});
+
+test('respects the operating system reduced-motion preference', () => {
+  assert.equal(pageTransitionsAvailable({
+    document: { startViewTransition() {} },
+    matchMedia: () => ({ matches: true }),
+  }), false);
 });
 
 test('dispatches normally when the View Transitions API is unavailable', () => {

--- a/test/performanceMode.test.js
+++ b/test/performanceMode.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolvePerformanceMode } from '../src/helpers/performanceMode.js';
+
+test('selects low performance mode from the kiosk query parameter', () => {
+  assert.equal(resolvePerformanceMode({ search: '?performance=low' }), 'low');
+  assert.equal(resolvePerformanceMode({ search: '' }), 'normal');
+});
+
+test('deployment config overrides the query parameter', () => {
+  assert.equal(resolvePerformanceMode({
+    config: { performanceMode: 'normal' },
+    search: '?performance=low',
+  }), 'normal');
+});

--- a/test/test_reflectrum_server.py
+++ b/test/test_reflectrum_server.py
@@ -25,6 +25,8 @@ class ReflectrumServerTests(unittest.TestCase):
             SimpleNamespace(stdout='HDMI-A-1 "Display"\n  Enabled: no\n'),
         ]
         with patch("reflectrum_server.shutil.which", return_value="/usr/bin/wlr-randr"), patch(
+            "reflectrum_server.os.path.exists", return_value=True
+        ), patch(
             "reflectrum_server.subprocess.run", side_effect=results
         ) as run:
             self.assertEqual(handler.display_command("off"), "off")
@@ -32,6 +34,18 @@ class ReflectrumServerTests(unittest.TestCase):
             "/usr/bin/wlr-randr", "--output", "HDMI-A-1", "--off"
         ])
         self.assertEqual(run.call_args_list[1].args[0], ["/usr/bin/wlr-randr"])
+
+    def test_display_command_uses_firmware_control_without_wayland(self):
+        handler = self.make_handler()
+        result = SimpleNamespace(stdout="display_power=0\n")
+        with patch(
+            "reflectrum_server.shutil.which",
+            side_effect=["/usr/bin/wlr-randr", "/usr/bin/vcgencmd"],
+        ), patch("reflectrum_server.os.path.exists", return_value=False), patch(
+            "reflectrum_server.subprocess.run", return_value=result
+        ) as run:
+            self.assertEqual(handler.display_command("off"), "off")
+        self.assertEqual(run.call_args.args[0], ["/usr/bin/vcgencmd", "display_power", "0"])
 
     def test_json_body_is_bounded_and_parsed(self):
         body = json.dumps({"power": "on"}).encode()


### PR DESCRIPTION
## Summary
- replace the Pi 3 Chromium/Xwayland/labwc render path with Cog/WPE WebKit on direct DRM at native 1366x768 with GLES rotation
- run the MX Creative Dialpad through a non-root headless Solaar service, including fixed Linux key codes and a debounced bidirectional wheel proxy for the Cog 0.16 input bug
- persist the renderer and input services, disable LightDM by default, and document the Chromium recovery path and input-group security boundary
- repair zram cold-start ordering and select Wayland display control only when a compositor socket exists
- make deploy, refresh, and screen-share tooling aware of the direct-DRM renderer

## Verification
- 6 Python tests passed
- 26 JavaScript tests passed
- Vite production build passed
- shell syntax, Python compilation, diff checks, and installed systemd unit verification passed
- deployed twice through the tracked Pi deployment path to adsb.local
- completed two Pi reboots; final boot reports running with zero failed units
- Cog, the loopback web server, the headless input bridge, and zram are enabled and active after reboot
- zram initializes 453 MiB with lz4 at priority 100; dphys-swapfile remains disabled
- user verified dramatically improved animation/scroll performance and working Back, Forward, display toggle, bottom-right navigation, and both big-wheel directions

## Direct-DRM tradeoffs
- WayVNC screen sharing requires the documented Chromium/LightDM fallback
- compositor-level Night Shift is retained for that fallback but is unavailable while Cog owns KMS
- mirror mode uses the smooth opaque curtain because full-KMS ignores legacy firmware DPMS requests
- the dedicated input service receives input-group access to Logitech hidraw and /dev/uinput; this is documented as a trusted-appliance security boundary

## Stack
Base: codex/home-assistant-dashboard (PR #30)