### PR TITLE
Fix menu sizing, weather layout, and Dialpad navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ scroll wheel, or programmable dial pad.
 ### Logitech MX Creative Dialpad
 
 The Dialpad is handled as a standard Bluetooth HID device; Reflectrum does not
-depend on Logi Options+. Vertical roller and horizontal dial events navigate,
-forward/select buttons open the highlighted item, and back buttons return to
-the previous screen. Bursty wheel events are throttled to one action every 90
-ms by default.
+depend on Logi Options+. The top-right vertical roller navigates, forward/select
+buttons open the highlighted item, and back buttons return to the previous
+screen. The large horizontal dial is deliberately reserved for experiences
+that need a second input axis. Bursty wheel events are throttled by default.
 
 Open `http://127.0.0.1:3000/?input-debug=1` on the mirror to see each raw
 keyboard, wheel, or mouse event and the Reflectrum action it produces. Controls

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -298,10 +298,12 @@ applies these rules without GTK or a graphical login:
 | Button 6 | Fade and toggle physical display power |
 | Left Scroll As Button 7 | Next item |
 
-The large wheel reports horizontal high-resolution mouse-wheel events. Cog
-0.16's DRM input back end loses one direction, so the headless bridge grabs only
-the `MX Dialpad Mouse` event device and emits debounced Up/Down keys for both
-signs. The smaller bottom-right control remains mapped to Next item.
+Cog 0.16's DRM input back end loses one direction from the top-right vertical
+roller. The headless bridge therefore grabs only the `MX Dialpad Mouse` event
+device and emits debounced Up/Down keys for both vertical-wheel signs. It keeps
+the large horizontal dial captured but unassigned so an app can use it as a
+separate control later. The smaller bottom-right control remains mapped to Next
+item.
 
 The installer also adds a version-pinned `uinput` udev rule. It grants the
 dedicated service's `input` group read/write access to Logitech `hidraw` devices

--- a/deploy/reflectrum_solaar_headless.py
+++ b/deploy/reflectrum_solaar_headless.py
@@ -49,8 +49,12 @@ def emit_key(key_code):
     diversion.simulate_uinput(diversion.evdev.ecodes.EV_KEY, key_code, 0)
 
 
-def dial_wheel_loop():
-    """Translate the Dialpad's horizontal wheel around Cog 0.16's DRM bug."""
+def navigation_wheel_loop():
+    """Translate the top-right vertical wheel around Cog 0.16's DRM bug.
+
+    The large horizontal dial remains captured and intentionally unassigned so it
+    can be used independently by future experiences such as games.
+    """
     cooldown_seconds = 0.11
     while not stopping.is_set():
         dial = None
@@ -74,7 +78,7 @@ def dial_wheel_loop():
                     break
                 if (
                     event.type != diversion.evdev.ecodes.EV_REL
-                    or event.code != diversion.evdev.ecodes.REL_HWHEEL
+                    or event.code != diversion.evdev.ecodes.REL_WHEEL
                     or event.value == 0
                 ):
                     continue
@@ -85,7 +89,7 @@ def dial_wheel_loop():
                 last_action_at = now
                 key_code = (
                     diversion.evdev.ecodes.KEY_UP
-                    if event.value < 0
+                    if event.value > 0
                     else diversion.evdev.ecodes.KEY_DOWN
                 )
                 emit_key(key_code)
@@ -126,7 +130,7 @@ def main():
     if not diversion.setup_uinput():
         raise RuntimeError("Could not create the Solaar virtual keyboard")
 
-    threading.Thread(target=dial_wheel_loop, name="dial-wheel", daemon=True).start()
+    threading.Thread(target=navigation_wheel_loop, name="navigation-wheel", daemon=True).start()
     listener.setup_scanner(status_changed, setting_changed, error_callback)
     configuration.defer_saves = True
     listener.start_all()

--- a/src/components/lockscreen/WeatherStamp.css
+++ b/src/components/lockscreen/WeatherStamp.css
@@ -19,7 +19,8 @@
   width: 150px;
   height: 150px;
   position: absolute;
-  transform: scale(.6);
+  left: 50%;
+  transform: translateX(-50%) scale(.6);
 }
 
 .weather-stamp > .temp {

--- a/src/components/lockscreen/WeatherStamp.jsx
+++ b/src/components/lockscreen/WeatherStamp.jsx
@@ -1,21 +1,6 @@
 import React, {Component} from 'react';
 import './WeatherStamp.css';
-
-export const weatherGlyph = (icon) => {
-  const glyphs = {
-    'clear-day': '☀',
-    'clear-night': '☾',
-    rain: '☂',
-    snow: '❄',
-    sleet: '◇',
-    wind: '≋',
-    fog: '≡',
-    cloudy: '☁',
-    'partly-cloudy-day': '⛅',
-    'partly-cloudy-night': '☁',
-  };
-  return glyphs[icon] || '•';
-};
+import { WeatherIcon } from '../weather/WeatherIcon';
 
 
 export class WeatherStamp extends Component {
@@ -25,9 +10,7 @@ export class WeatherStamp extends Component {
       <div className="animated flipInY weather-stamp">
         <p className="time">{this.props.time}</p>
         <div className="icon">
-          <div className="canvas-sizer" aria-hidden="true" style={{fontSize: '96px'}}>
-            {weatherGlyph(this.props.icon)}
-          </div>
+          <WeatherIcon className="canvas-sizer" icon={this.props.icon} label={this.props.summary} />
         </div>
         <p className="temp">{this.props.temperature}</p>
       </div>

--- a/src/components/menu/Menu.css
+++ b/src/components/menu/Menu.css
@@ -30,7 +30,8 @@ body > div {
 
 .menu-list {
   position: relative;
-  --menu-item-height: min(200px, calc((100vh - 260px) / var(--menu-item-count)));
+  /* Keep the selector geometry stable as users move between menus. */
+  --menu-item-height: min(158px, calc((100vh - 260px) / 7));
 }
 
 .menu-list-select-item {

--- a/src/components/menu/MenuList.jsx
+++ b/src/components/menu/MenuList.jsx
@@ -8,7 +8,7 @@ class MenuList extends Component {
   render() {
     const props = this.props;
     return (
-        <div className="menu-list" style={{ '--menu-item-count': props.items.length }}>
+        <div className="menu-list">
           <MenuListSelectedItem selectedItem={props.selectedItem} className="menu-list-select-item" />
           <div>
           {

--- a/src/components/weather/Weather.css
+++ b/src/components/weather/Weather.css
@@ -1,11 +1,18 @@
 .gggg {
-  height: 1366px;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  min-height: 100vh;
+  overflow: hidden;
+  display: flow-root;
   background-color: #254D6A;
   font-family: 'Lato', sans-serif;
   color: white;
 }
 
 .gggg .clock {
+  box-sizing: border-box;
+  margin: 0;
   padding-top: 20px;
   color: white;
   font-size: 25px;
@@ -157,7 +164,7 @@
 }
 
 .weather-status {
-  min-height: 1366px;
+  min-height: 100vh;
   box-sizing: border-box;
   padding: 120px 70px;
   background: #254D6A;
@@ -167,9 +174,9 @@
 }
 
 .weather-page-glyph {
+  width: 90px;
   height: 100px;
-  font-size: 82px;
-  line-height: 100px;
+  margin: 0 auto;
 }
 
 .rainAt {

--- a/src/components/weather/Weather.jsx
+++ b/src/components/weather/Weather.jsx
@@ -5,7 +5,7 @@ import './Weather.css';
 import { MirrorEvents } from '../../helpers/events';
 import { resolveLocation } from '../../providers/location';
 import { fetchWeather } from '../../providers/weather';
-import { weatherGlyph } from '../lockscreen/WeatherStamp';
+import { WeatherIcon } from './WeatherIcon';
 
 class Weather extends Component {
   state = { status: 'loading', weather: null, error: '' };
@@ -72,7 +72,7 @@ class Weather extends Component {
           {weather.hours.map((hour) => (
             <div className="weaStamp" key={hour.time}>
               <p className="weatherAt">{hour.time}</p>
-              <div className="weather-page-glyph" aria-label={hour.summary}>{weatherGlyph(hour.icon)}</div>
+              <div className="weather-page-glyph"><WeatherIcon icon={hour.icon} label={hour.summary} /></div>
               <p className="tempAt">{hour.temperature}</p>
               <p className="rainAt">{hour.precipitationChance}</p>
             </div>

--- a/src/components/weather/WeatherIcon.css
+++ b/src/components/weather/WeatherIcon.css
@@ -1,0 +1,16 @@
+.weather-icon {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.weather-icon-fill {
+  fill: currentColor;
+  stroke: none;
+}

--- a/src/components/weather/WeatherIcon.jsx
+++ b/src/components/weather/WeatherIcon.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import './WeatherIcon.css';
+
+const Cloud = () => (
+  <path d="M27 68h47a16 16 0 0 0 1-32 25 25 0 0 0-47 8 12 12 0 0 0-1 24Z" />
+);
+
+const Sun = () => (
+  <>
+    <circle cx="50" cy="50" r="17" />
+    <path d="M50 10v12M50 78v12M10 50h12M78 50h12M22 22l9 9M69 69l9 9M78 22l-9 9M31 69l-9 9" />
+  </>
+);
+
+const Moon = () => <path d="M68 69A30 30 0 1 1 55 21a25 25 0 0 0 13 48Z" />;
+
+const Rain = ({ light = false }) => (
+  <>
+    <Cloud />
+    <path d={light ? 'M36 78l-4 8M54 78l-4 8M72 78l-4 8' : 'M34 77l-6 13M54 77l-6 13M74 77l-6 13'} />
+  </>
+);
+
+const Snow = () => (
+  <>
+    <Cloud />
+    <path d="M34 78v12M28 81l12 6M40 81l-12 6M62 78v12M56 81l12 6M68 81l-12 6" />
+  </>
+);
+
+export const WeatherIcon = ({ icon, label, className = '' }) => {
+  let art;
+  switch (icon) {
+    case 'clear-day': art = <Sun />; break;
+    case 'clear-night': art = <Moon />; break;
+    case 'partly-cloudy-day': art = <><g transform="translate(-18 -18) scale(.72)"><Sun /></g><Cloud /></>; break;
+    case 'partly-cloudy-night': art = <><g transform="translate(-15 -17) scale(.72)"><Moon /></g><Cloud /></>; break;
+    case 'fog': art = <><Cloud /><path d="M19 77h62M25 87h50" /></>; break;
+    case 'drizzle': art = <Rain light />; break;
+    case 'rain':
+    case 'showers': art = <Rain />; break;
+    case 'sleet': art = <><Cloud /><path d="M33 77l-5 12M53 78v12M47 81l12 6M59 81l-12 6M75 77l-5 12" /></>; break;
+    case 'snow': art = <Snow />; break;
+    case 'thunderstorm': art = <><Cloud /><path className="weather-icon-fill" d="M54 72 40 90h11l-4 10 18-23H54Z" /></>; break;
+    case 'hail': art = <><Cloud /><path d="M43 79 36 86l7 7 7-7ZM68 79l-7 7 7 7 7-7Z" /></>; break;
+    case 'cloudy':
+    default: art = <Cloud />;
+  }
+
+  return (
+    <svg
+      className={`weather-icon ${className}`.trim()}
+      viewBox="0 0 100 100"
+      role={label ? 'img' : undefined}
+      aria-label={label}
+      aria-hidden={label ? undefined : true}
+    >
+      {art}
+    </svg>
+  );
+};
+
+export default WeatherIcon;

--- a/src/providers/weather.js
+++ b/src/providers/weather.js
@@ -1,13 +1,21 @@
 const FORECAST_URL = 'https://api.open-meteo.com/v1/forecast';
 
-const weatherCode = (code, isDay = true) => {
+export const weatherCode = (code, isDay = true) => {
   if (code === 0) return { summary: 'Clear', icon: isDay ? 'clear-day' : 'clear-night' };
-  if (code === 1 || code === 2) return { summary: 'Partly cloudy', icon: isDay ? 'partly-cloudy-day' : 'partly-cloudy-night' };
-  if (code === 3) return { summary: 'Cloudy', icon: 'cloudy' };
+  if (code === 1) return { summary: 'Mostly clear', icon: isDay ? 'partly-cloudy-day' : 'partly-cloudy-night' };
+  if (code === 2) return { summary: 'Partly cloudy', icon: isDay ? 'partly-cloudy-day' : 'partly-cloudy-night' };
+  if (code === 3) return { summary: 'Overcast', icon: 'cloudy' };
   if (code === 45 || code === 48) return { summary: 'Foggy', icon: 'fog' };
-  if ((code >= 51 && code <= 67) || (code >= 80 && code <= 82)) return { summary: 'Rain', icon: 'rain' };
-  if ((code >= 71 && code <= 77) || (code >= 85 && code <= 86)) return { summary: 'Snow', icon: 'snow' };
-  if (code >= 95) return { summary: 'Thunderstorms', icon: 'rain' };
+  if (code >= 51 && code <= 55) return { summary: 'Drizzle', icon: 'drizzle' };
+  if (code === 56 || code === 57) return { summary: 'Freezing drizzle', icon: 'sleet' };
+  if (code >= 61 && code <= 65) return { summary: 'Rain', icon: 'rain' };
+  if (code === 66 || code === 67) return { summary: 'Freezing rain', icon: 'sleet' };
+  if (code >= 71 && code <= 75) return { summary: 'Snow', icon: 'snow' };
+  if (code === 77) return { summary: 'Snow grains', icon: 'snow' };
+  if (code >= 80 && code <= 82) return { summary: 'Rain showers', icon: 'showers' };
+  if (code === 85 || code === 86) return { summary: 'Snow showers', icon: 'snow' };
+  if (code === 95) return { summary: 'Thunderstorm', icon: 'thunderstorm' };
+  if (code === 96 || code === 99) return { summary: 'Thunderstorm with hail', icon: 'hail' };
   return { summary: 'Conditions unavailable', icon: 'cloudy' };
 };
 
@@ -25,7 +33,7 @@ export const buildWeatherUrl = ({ lat, long }) => {
     latitude: String(lat),
     longitude: String(long),
     current: 'temperature_2m,relative_humidity_2m,apparent_temperature,precipitation,weather_code,wind_speed_10m,is_day',
-    hourly: 'temperature_2m,precipitation_probability,weather_code',
+    hourly: 'temperature_2m,precipitation_probability,weather_code,is_day',
     daily: 'weather_code,temperature_2m_max,temperature_2m_min,sunrise,sunset,precipitation_probability_max',
     temperature_unit: 'fahrenheit',
     wind_speed_unit: 'mph',
@@ -50,7 +58,7 @@ export const normalizeWeather = (payload, location) => {
       time: offset === 0 ? 'Now' : timeLabel(time),
       temperature: temperature(payload.hourly.temperature_2m[index]),
       precipitationChance: percentage(payload.hourly.precipitation_probability[index]),
-      ...weatherCode(payload.hourly.weather_code[index]),
+      ...weatherCode(payload.hourly.weather_code[index], payload.hourly.is_day?.[index] !== 0),
     };
   });
 

--- a/test/weather.test.js
+++ b/test/weather.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { normalizeLocation } from '../src/providers/location.js';
-import { buildWeatherUrl, normalizeWeather } from '../src/providers/weather.js';
+import { buildWeatherUrl, normalizeWeather, weatherCode } from '../src/providers/weather.js';
 
 test('normalizes configured coordinates without exposing them in source', () => {
   assert.deepEqual(
@@ -15,6 +15,7 @@ test('builds a keyless Open-Meteo request', () => {
   const url = new URL(buildWeatherUrl({ lat: 35.1, long: -118.9 }));
   assert.equal(url.hostname, 'api.open-meteo.com');
   assert.equal(url.searchParams.get('temperature_unit'), 'fahrenheit');
+  assert.match(url.searchParams.get('hourly'), /is_day/);
   assert.equal(url.searchParams.has('apikey'), false);
 });
 
@@ -35,6 +36,7 @@ test('normalizes current, hourly, and daily weather', () => {
       temperature_2m: [79, 81, 83],
       precipitation_probability: [0, 5, 10],
       weather_code: [0, 1, 2],
+      is_day: [1, 1, 0],
     },
     daily: {
       time: ['2026-08-16'],
@@ -48,9 +50,23 @@ test('normalizes current, hourly, and daily weather', () => {
   }, { lat: 35.1, long: -118.9, name: 'Home' });
 
   assert.equal(result.location, 'Home');
-  assert.equal(result.current.summary, 'Partly cloudy');
+  assert.equal(result.current.summary, 'Mostly clear');
   assert.equal(result.current.temperature, '81º');
   assert.equal(result.hours[0].time, 'Now');
   assert.equal(result.hours[0].temperature, '81º');
   assert.equal(result.today.high, '90º');
+});
+
+test('maps the complete Open-Meteo WMO condition set to supported icons', () => {
+  const cases = [
+    [0, 'clear-day'], [1, 'partly-cloudy-day'], [2, 'partly-cloudy-day'],
+    [3, 'cloudy'], [45, 'fog'], [48, 'fog'], [51, 'drizzle'], [55, 'drizzle'],
+    [56, 'sleet'], [57, 'sleet'], [61, 'rain'], [65, 'rain'], [66, 'sleet'],
+    [67, 'sleet'], [71, 'snow'], [75, 'snow'], [77, 'snow'], [80, 'showers'],
+    [82, 'showers'], [85, 'snow'], [86, 'snow'], [95, 'thunderstorm'],
+    [96, 'hail'], [99, 'hail'],
+  ];
+  cases.forEach(([code, icon]) => assert.equal(weatherCode(code).icon, icon, `WMO ${code}`));
+  assert.equal(weatherCode(0, false).icon, 'clear-night');
+  assert.equal(weatherCode(2, false).icon, 'partly-cloudy-night');
 });


### PR DESCRIPTION
## Summary
- keep menu rows and selector height consistent across every menu
- make weather fill the viewport and replace font-dependent glyphs with complete SVG WMO condition icons
- move menu navigation to the top-right vertical roller and reserve the large horizontal dial

## Verification
- npm run check
- browser layout check at 768 × 1366
- main and screensaver menu rows both measure 158px

## Stack
1. **This PR**
2. #34
3. #33
4. #35