### PR TITLE
Add a dial-controlled racing performance test

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ scroll wheel, or programmable dial pad.
 The Dialpad is handled as a standard Bluetooth HID device; Reflectrum does not
 depend on Logi Options+. The top-right vertical roller navigates, forward/select
 buttons open the highlighted item, and back buttons return to the previous
-screen. The large horizontal dial is deliberately reserved for experiences
-that need a second input axis. Bursty wheel events are throttled by default.
+screen. The large horizontal dial is an independent input axis: the Racing
+screen uses it for steering, while the forward button provides a short speed
+boost. Bursty wheel events are throttled by default.
 
 Open `http://127.0.0.1:3000/?input-debug=1` on the mirror to see each raw
 keyboard, wheel, or mouse event and the Reflectrum action it produces. Controls

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -300,10 +300,10 @@ applies these rules without GTK or a graphical login:
 
 Cog 0.16's DRM input back end loses one direction from the top-right vertical
 roller. The headless bridge therefore grabs only the `MX Dialpad Mouse` event
-device and emits debounced Up/Down keys for both vertical-wheel signs. It keeps
-the large horizontal dial captured but unassigned so an app can use it as a
-separate control later. The smaller bottom-right control remains mapped to Next
-item.
+device and emits debounced Up/Down keys for both vertical-wheel signs. The large
+horizontal dial emits F14/F15, which Reflectrum reserves as independent left and
+right steering controls for the Racing screen. The smaller bottom-right control
+remains mapped to Next item.
 
 The installer also adds a version-pinned `uinput` udev rule. It grants the
 dedicated service's `input` group read/write access to Logitech `hidraw` devices

--- a/deploy/reflectrum_solaar_headless.py
+++ b/deploy/reflectrum_solaar_headless.py
@@ -25,6 +25,8 @@ HEADLESS_KEY_CODES = {
     "Escape": diversion.evdev.ecodes.KEY_ESC,
     "Return": diversion.evdev.ecodes.KEY_ENTER,
     "F13": diversion.evdev.ecodes.KEY_F13,
+    "F14": diversion.evdev.ecodes.KEY_F14,
+    "F15": diversion.evdev.ecodes.KEY_F15,
     "Down": diversion.evdev.ecodes.KEY_DOWN,
 }
 
@@ -78,9 +80,18 @@ def navigation_wheel_loop():
                     break
                 if (
                     event.type != diversion.evdev.ecodes.EV_REL
-                    or event.code != diversion.evdev.ecodes.REL_WHEEL
                     or event.value == 0
                 ):
+                    continue
+
+                if event.code == diversion.evdev.ecodes.REL_HWHEEL:
+                    emit_key(
+                        diversion.evdev.ecodes.KEY_F14
+                        if event.value < 0
+                        else diversion.evdev.ecodes.KEY_F15
+                    )
+                    continue
+                if event.code != diversion.evdev.ecodes.REL_WHEEL:
                     continue
 
                 now = time.monotonic()

--- a/deploy/reflectrum_solaar_headless.py
+++ b/deploy/reflectrum_solaar_headless.py
@@ -58,6 +58,7 @@ def navigation_wheel_loop():
     can be used independently by future experiences such as games.
     """
     cooldown_seconds = 0.11
+    steering_cooldown_seconds = 0.035
     while not stopping.is_set():
         dial = None
         try:
@@ -75,6 +76,7 @@ def navigation_wheel_loop():
             logger.info("capturing Dialpad wheel from %s", dial.path)
             dial.grab()
             last_action_at = 0.0
+            last_steering_at = 0.0
             for event in dial.read_loop():
                 if stopping.is_set():
                     break
@@ -85,6 +87,10 @@ def navigation_wheel_loop():
                     continue
 
                 if event.code == diversion.evdev.ecodes.REL_HWHEEL:
+                    now = time.monotonic()
+                    if now - last_steering_at < steering_cooldown_seconds:
+                        continue
+                    last_steering_at = now
                     emit_key(
                         diversion.evdev.ecodes.KEY_F14
                         if event.value < 0

--- a/src/components/RacingScreensaver.jsx
+++ b/src/components/RacingScreensaver.jsx
@@ -1,0 +1,9 @@
+import { connect } from 'react-redux';
+import RacingGame from './racing/RacingGame';
+
+const mapDispatchToProps = (dispatch) => ({
+  secondaryHold: () => dispatch({ type: 'OPEN_MAIN_MENU' }),
+  secondaryClick: () => dispatch({ type: 'BACK' }),
+});
+
+export const RacingScreensaver = connect(null, mapDispatchToProps)(RacingGame);

--- a/src/components/ScreensaverMenu.jsx
+++ b/src/components/ScreensaverMenu.jsx
@@ -31,6 +31,11 @@ export const screensaverMenu = {
       color: "#58D6C7",
       key: "AQUARIUM"
     },
+    {
+      name: "racing",
+      color: "#FF3B30",
+      key: "RACING"
+    },
 
   ]
 }

--- a/src/components/racing/RacingGame.css
+++ b/src/components/racing/RacingGame.css
@@ -1,0 +1,6 @@
+.racing-game { position: fixed; inset: 0; overflow: hidden; background: #07152e; color: white; font-family: 'Lato', sans-serif; }
+.racing-game canvas { display: block; width: 100%; height: 100%; image-rendering: auto; }
+.racing-hud { position: absolute; top: 34px; left: 32px; right: 32px; display: flex; justify-content: space-between; align-items: baseline; padding: 16px 20px; background: rgba(0, 0, 0, .48); border-left: 5px solid #ff3b30; letter-spacing: .08em; }
+.racing-hud strong { font-size: 28px; }
+.racing-hud span { color: #86e7ff; font-size: 22px; }
+.racing-help { position: absolute; left: 0; right: 0; bottom: 26px; text-align: center; font-size: 15px; letter-spacing: .08em; text-shadow: 0 2px 5px #000; }

--- a/src/components/racing/RacingGame.jsx
+++ b/src/components/racing/RacingGame.jsx
@@ -1,0 +1,164 @@
+import React, { useEffect, useRef } from 'react';
+import { MirrorEvents } from '../../helpers/events';
+import { advanceRace, applyBoost, applySteering, createRaceState } from '../../providers/racing';
+import './RacingGame.css';
+
+const WIDTH = 384;
+const HEIGHT = 683;
+const HORIZON = 178;
+const roadCenter = (state, depth) => WIDTH / 2
+  + Math.sin(state.distance * 0.012 + depth * 2.6) * 48 * depth
+  - state.carX * 92 * depth;
+
+const drawBackground = (context, state) => {
+  const sky = context.createLinearGradient(0, 0, 0, HORIZON);
+  sky.addColorStop(0, '#07152e');
+  sky.addColorStop(1, '#e55946');
+  context.fillStyle = sky;
+  context.fillRect(0, 0, WIDTH, HORIZON);
+  context.fillStyle = '#131b35';
+  context.beginPath();
+  context.moveTo(0, HORIZON);
+  for (let x = 0; x <= WIDTH; x += 24) {
+    context.lineTo(x, HORIZON - 24 - Math.sin(x * .043 + state.distance * .002) * 23);
+  }
+  context.lineTo(WIDTH, HORIZON);
+  context.fill();
+  context.fillStyle = '#183c2b';
+  context.fillRect(0, HORIZON, WIDTH, HEIGHT - HORIZON);
+};
+
+const drawRoad = (context, state) => {
+  const segments = 34;
+  const phase = (state.distance * 1.4) % 1;
+  for (let index = segments; index >= 0; index -= 1) {
+    const nearDepth = Math.min(1, (index + phase) / segments);
+    const farDepth = Math.min(1, (index - 1 + phase) / segments);
+    const nearY = HORIZON + nearDepth * nearDepth * (HEIGHT - HORIZON);
+    const farY = HORIZON + farDepth * farDepth * (HEIGHT - HORIZON);
+    const nearHalf = 18 + nearDepth * 210;
+    const farHalf = 18 + farDepth * 210;
+    const nearCenter = roadCenter(state, nearDepth);
+    const farCenter = roadCenter(state, farDepth);
+    const alternate = (Math.floor(state.distance * .06) + index) % 2 === 0;
+    context.fillStyle = alternate ? '#d9d9d4' : '#ef4b3e';
+    context.beginPath();
+    context.moveTo(farCenter - farHalf - 10 * farDepth, farY);
+    context.lineTo(farCenter + farHalf + 10 * farDepth, farY);
+    context.lineTo(nearCenter + nearHalf + 10 * nearDepth, nearY);
+    context.lineTo(nearCenter - nearHalf - 10 * nearDepth, nearY);
+    context.fill();
+    context.fillStyle = alternate ? '#24252a' : '#292a2f';
+    context.beginPath();
+    context.moveTo(farCenter - farHalf, farY);
+    context.lineTo(farCenter + farHalf, farY);
+    context.lineTo(nearCenter + nearHalf, nearY);
+    context.lineTo(nearCenter - nearHalf, nearY);
+    context.fill();
+    if (alternate && nearDepth > .12) {
+      context.strokeStyle = 'rgba(255,255,255,.82)';
+      context.lineWidth = Math.max(1, nearDepth * 4);
+      [-1 / 3, 1 / 3].forEach((lane) => {
+        context.beginPath();
+        context.moveTo(farCenter + lane * farHalf, farY);
+        context.lineTo(nearCenter + lane * nearHalf, nearY);
+        context.stroke();
+      });
+    }
+  }
+};
+
+const drawTraffic = (context, state) => {
+  [0.17, 0.39, 0.67].forEach((baseDepth, index) => {
+    const depth = (baseDepth + state.distance * .0014 * (index + 1)) % .82 + .08;
+    const lane = [-.46, .38, -.08][index];
+    const size = 10 + depth * 34;
+    const x = roadCenter(state, depth) + lane * (18 + depth * 190);
+    const y = HORIZON + depth * depth * (HEIGHT - HORIZON);
+    context.fillStyle = ['#54b9ff', '#ffd54a', '#ee6677'][index];
+    context.fillRect(x - size / 2, y - size, size, size * .72);
+    context.fillStyle = '#111';
+    context.fillRect(x - size * .32, y - size * .82, size * .64, size * .24);
+  });
+};
+
+const drawCar = (context, state) => {
+  const x = WIDTH / 2 + state.carX * 42;
+  const y = HEIGHT - 86;
+  context.save();
+  context.translate(x, y);
+  context.rotate(state.steering * .08);
+  context.fillStyle = state.offRoad ? '#ffb13b' : '#ff3b30';
+  context.beginPath();
+  context.moveTo(-31, 30);
+  context.lineTo(-24, -25);
+  context.lineTo(-13, -43);
+  context.lineTo(13, -43);
+  context.lineTo(24, -25);
+  context.lineTo(31, 30);
+  context.closePath();
+  context.fill();
+  context.fillStyle = '#bde8ff';
+  context.fillRect(-14, -28, 28, 18);
+  context.fillStyle = '#0c1016';
+  context.fillRect(-34, 12, 8, 20);
+  context.fillRect(26, 12, 8, 20);
+  context.restore();
+};
+
+const drawFrame = (context, state) => {
+  drawBackground(context, state);
+  drawRoad(context, state);
+  drawTraffic(context, state);
+  drawCar(context, state);
+};
+
+export const RacingGame = ({ secondaryClick, secondaryHold }) => {
+  const canvasRef = useRef(null);
+  const fpsRef = useRef(null);
+  const speedRef = useRef(null);
+  const stateRef = useRef(createRaceState());
+
+  useEffect(() => {
+    const handlers = [
+      MirrorEvents.addListener('STEER_LEFT', () => { stateRef.current = applySteering(stateRef.current, -1); }),
+      MirrorEvents.addListener('STEER_RIGHT', () => { stateRef.current = applySteering(stateRef.current, 1); }),
+      MirrorEvents.addListener('PRIMARY_CLICK', () => { stateRef.current = applyBoost(stateRef.current); }),
+      MirrorEvents.addListener('SECONDARY_CLICK', secondaryClick),
+      MirrorEvents.addListener('SECONDARY_HOLD', secondaryHold),
+    ];
+    const context = canvasRef.current.getContext('2d', { alpha: false });
+    let animationFrame;
+    let previousTime = performance.now();
+    let sampleStart = previousTime;
+    let sampleFrames = 0;
+    const animate = (time) => {
+      stateRef.current = advanceRace(stateRef.current, (time - previousTime) / 1000);
+      previousTime = time;
+      drawFrame(context, stateRef.current);
+      sampleFrames += 1;
+      if (time - sampleStart >= 500) {
+        fpsRef.current.textContent = `${Math.round(sampleFrames * 1000 / (time - sampleStart))} FPS`;
+        speedRef.current.textContent = `${Math.round(stateRef.current.speed * 125)} MPH`;
+        sampleStart = time;
+        sampleFrames = 0;
+      }
+      animationFrame = requestAnimationFrame(animate);
+    };
+    animationFrame = requestAnimationFrame(animate);
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      handlers.forEach((handler) => handler.remove());
+    };
+  }, [secondaryClick, secondaryHold]);
+
+  return (
+    <div className="racing-game">
+      <canvas ref={canvasRef} width={WIDTH} height={HEIGHT} aria-label="Dial-controlled racing performance test" />
+      <div className="racing-hud"><strong ref={speedRef}>90 MPH</strong><span ref={fpsRef}>— FPS</span></div>
+      <div className="racing-help">Large dial steers · Forward boosts · Back exits</div>
+    </div>
+  );
+};
+
+export default RacingGame;

--- a/src/helpers/icons.jsx
+++ b/src/helpers/icons.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 const store = {
+  'racing': `<svg width="80px" height="80px" viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M40 7a33 33 0 1 0 0 66 33 33 0 0 0 0-66Zm0 9a24 24 0 0 1 22 14H18a24 24 0 0 1 22-14Zm-24 25h18v22A24 24 0 0 1 16 41Zm30 22V41h18a24 24 0 0 1-18 22Z"/><circle cx="40" cy="36" r="9" fill="currentColor"/></svg>`,
   'home': `<svg width="80px" height="80px" viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M7 38 40 9l33 29-6 7-5-4v30H46V50H34v21H18V41l-5 4-6-7Z"/></svg>`,
   'linear': `<svg width="80px" height="80px" viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M8 46a34 34 0 0 0 26 26L8 46Zm0-12 38 38c4-1 8-2 11-4L12 23c-2 3-3 7-4 11Zm9-19 48 48c3-3 5-6 6-10L27 9c-4 1-7 3-10 6Zm22-9 35 35v-1A34 34 0 0 0 40 6h-1Z"/></svg>`,
   'aquarium': `<svg width="80px" height="80px" viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M51 24c-10-6-24-1-31 8-5-5-11-8-18-8 3 6 3 26 0 32 7 0 13-3 18-8 7 9 21 14 31 8 8-5 13-13 15-16-2-3-7-11-15-16Zm4 15a4 4 0 1 1 0-8 4 4 0 0 1 0 8Z"/><path fill="currentColor" opacity=".7" d="M67 15a5 5 0 1 0 0-10 5 5 0 0 0 0 10Zm5 16a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z"/></svg>`,

--- a/src/helpers/inputMapping.js
+++ b/src/helpers/inputMapping.js
@@ -1,5 +1,7 @@
 export const DEFAULT_KEY_MAP = Object.freeze({
   F13: 'DISPLAY_TOGGLE',
+  F14: 'STEER_LEFT',
+  F15: 'STEER_RIGHT',
   ArrowUp: 'UP_CLICK',
   PageUp: 'UP_CLICK',
   MediaTrackPrevious: 'UP_CLICK',

--- a/src/helpers/pages.jsx
+++ b/src/helpers/pages.jsx
@@ -13,6 +13,7 @@ import { FishTankScreensaver } from '../components/FishTankScreensaver.jsx';
 import LinearIssues from '../components/linear/LinearIssues.jsx';
 import HomeDashboard from '../components/home/HomeDashboard.jsx';
 import Settings from '../components/settings/Settings.jsx';
+import { RacingScreensaver } from '../components/RacingScreensaver.jsx';
 
 export const pages = {
   "MAIN_MENU": <MainMenu />,
@@ -28,5 +29,6 @@ export const pages = {
   "AQUARIUM": <FishTankScreensaver />,
   "LINEAR": <LinearIssues />,
   "HOME": <HomeDashboard />,
-  "SETTINGS": <Settings />
+  "SETTINGS": <Settings />,
+  "RACING": <RacingScreensaver />
 }

--- a/src/providers/racing.js
+++ b/src/providers/racing.js
@@ -1,0 +1,25 @@
+const clamp = (value, minimum, maximum) => Math.max(minimum, Math.min(maximum, value));
+
+export const createRaceState = () => ({ carX: 0, steering: 0, speed: 0.72, distance: 0, offRoad: false });
+
+export const applySteering = (state, direction) => ({
+  ...state,
+  steering: clamp(state.steering + Math.sign(direction) * 0.34, -1, 1),
+});
+
+export const applyBoost = (state) => ({ ...state, speed: clamp(state.speed + 0.12, 0, 1) });
+
+export const advanceRace = (state, elapsedSeconds) => {
+  const dt = clamp(elapsedSeconds, 0, 0.05);
+  const carX = clamp(state.carX + state.steering * dt * 1.65, -1.35, 1.35);
+  const offRoad = Math.abs(carX) > 0.82;
+  const targetSpeed = offRoad ? 0.34 : 0.78;
+  const speed = clamp(state.speed + (targetSpeed - state.speed) * dt * 2.4, 0.25, 1);
+  return {
+    carX,
+    offRoad,
+    speed,
+    distance: state.distance + speed * dt * 95,
+    steering: state.steering * Math.max(0, 1 - dt * 3.1),
+  };
+};

--- a/test/input.test.js
+++ b/test/input.test.js
@@ -8,6 +8,8 @@ import {
 
 test('maps standard navigation and Logitech-friendly media/browser keys', () => {
   assert.equal(resolveKeyAction({ key: 'F13', code: 'F13' }), 'DISPLAY_TOGGLE');
+  assert.equal(resolveKeyAction({ key: 'F14', code: 'F14' }), 'STEER_LEFT');
+  assert.equal(resolveKeyAction({ key: 'F15', code: 'F15' }), 'STEER_RIGHT');
   assert.equal(resolveKeyAction({ key: 'ArrowUp', code: 'ArrowUp' }), 'UP_CLICK');
   assert.equal(resolveKeyAction({ key: 'MediaTrackNext', code: '' }), 'DOWN_CLICK');
   assert.equal(resolveKeyAction({ key: 'BrowserForward', code: '' }), 'PRIMARY_CLICK');

--- a/test/racing.test.js
+++ b/test/racing.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { advanceRace, applyBoost, applySteering, createRaceState } from '../src/providers/racing.js';
+
+test('steering impulses move the car and decay smoothly', () => {
+  const steered = applySteering(createRaceState(), 1);
+  const advanced = advanceRace(steered, 0.05);
+  assert.ok(advanced.carX > 0);
+  assert.ok(advanced.steering > 0 && advanced.steering < steered.steering);
+  assert.ok(advanced.distance > 0);
+});
+
+test('leaving the road slows the car and boost remains bounded', () => {
+  const offRoad = advanceRace({ ...createRaceState(), carX: 1, speed: 1 }, 0.05);
+  assert.equal(offRoad.offRoad, true);
+  assert.ok(offRoad.speed < 1);
+  assert.equal(applyBoost({ ...offRoad, speed: .96 }).speed, 1);
+});


### PR DESCRIPTION
## Summary
- add a half-resolution Canvas racing screen with live FPS and speed telemetry
- map the large Dialpad wheel to dedicated F14/F15 steering events
- keep the top-right roller dedicated to menu navigation
- support steering, off-road slowdown, forward-button boost, and back-to-exit

## Verification
- npm run check
- 768 × 1366 browser run: 384 × 683 render buffer at 120 FPS on the development Mac

## Stack
1. #32
2. #34
3. **This PR**
4. #35