### PR TITLE
Restore the map with CARTO dark tiles

### DIFF
--- a/src/components/MapScreensaver.jsx
+++ b/src/components/MapScreensaver.jsx
@@ -19,6 +19,6 @@ const mapDispatchToProps = (dispatch) => {
 }
 
 export const MapScreensaver = connect(
-  (state) => {return {}},
+  (state) => ({ locationCache: state.locationCache }),
   mapDispatchToProps
 )(Map)

--- a/src/components/map/Map.css
+++ b/src/components/map/Map.css
@@ -1,0 +1,78 @@
+.map-page,
+.map-status {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  background: #090b0e;
+  color: #fff;
+  font-family: 'Lato', sans-serif;
+}
+
+.map-status {
+  box-sizing: border-box;
+  padding: 120px 70px;
+  font-size: 38px;
+  text-align: center;
+}
+
+.map-tile-layer,
+.map-shade { position: absolute; inset: 0; }
+
+.map-tile {
+  position: absolute;
+  width: 256px;
+  height: 256px;
+  user-select: none;
+}
+
+.map-shade {
+  background: radial-gradient(circle at center, transparent 20%, rgba(0, 0, 0, .38) 100%);
+  pointer-events: none;
+}
+
+.map-center-marker {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 34px;
+  height: 34px;
+  box-sizing: border-box;
+  transform: translate(-50%, -50%) rotate(-45deg);
+  border: 4px solid #fff;
+  border-radius: 50% 50% 50% 0;
+  background: #e74c3c;
+  box-shadow: 0 3px 18px rgba(0, 0, 0, .65);
+}
+
+.map-center-marker span {
+  position: absolute;
+  inset: 8px;
+  border-radius: 50%;
+  background: #fff;
+}
+
+.map-location-label {
+  position: absolute;
+  top: calc(50% + 38px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 9px 14px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, .78);
+  font-size: 20px;
+  letter-spacing: .08em;
+  white-space: nowrap;
+}
+
+.map-attribution {
+  position: absolute;
+  right: 8px;
+  bottom: 6px;
+  padding: 4px 6px;
+  background: rgba(0, 0, 0, .72);
+  color: #bbb;
+  font-size: 11px;
+  letter-spacing: 0;
+}
+
+.map-attribution a { color: #ddd; }

--- a/src/components/map/Map.jsx
+++ b/src/components/map/Map.jsx
@@ -1,56 +1,58 @@
 import React, { Component } from 'react';
-
 import { MirrorEvents } from '../../helpers/events';
+import { resolveLocation } from '../../providers/location';
+import { buildTileGrid } from '../../providers/map';
+import './Map.css';
 
 export class Map extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      link: this.mapSrc("San Mateo,CA", 13)
-    }
-    this.mapSrc = this.mapSrc.bind(this);
-  }
+  state = { status: 'loading', location: null, error: '' };
 
   componentDidMount() {
-    const props = this.props;
-    this.handlers = []
-    this.handlers.push(
-      MirrorEvents.addListener('SECONDARY_HOLD', () => {
-        props.secondaryHold()
-      })
-    );
-    this.handlers.push(
-      MirrorEvents.addListener('SECONDARY_CLICK', () => {
-        props.secondaryClick()
-      })
-    );
+    this.handlers = [
+      MirrorEvents.addListener('SECONDARY_HOLD', this.props.secondaryHold),
+      MirrorEvents.addListener('SECONDARY_CLICK', this.props.secondaryClick),
+    ];
+    this.loadLocation();
   }
 
   componentWillUnmount() {
-    this.handlers.map((handler) =>{
-      handler.remove();
-    })
+    this.handlers.forEach((handler) => handler.remove());
   }
 
-  mapSrc(location, zoom) {
-    return "\'https://maps.googleapis.com/maps/api/staticmap?center="+location+
-      "&zoom="+zoom+"&format=png&sensor=false&scale=2&size="+window.innerWidth+
-      "x"+window.innerHeight+"&maptype=roadmap&style=visibility:on|weight:1|invert_lightness:true|saturation:-100|lightness:1\'"
+  async loadLocation() {
+    try {
+      const location = await resolveLocation(this.props.locationCache);
+      this.setState({ status: 'ready', location, error: '' });
+    } catch (error) {
+      this.setState({ status: 'error', location: null, error: error.message });
+    }
   }
 
   render() {
-    var styles = {
-      map: {
-        height: "1366px",
-        width: "768px",
-        backgroundSize: "cover",
-        backgroundPosition: "center",
-        backgroundImage: "url("+this.state.link+")"
-      }
-    }
+    if (this.state.status === 'loading') return <div className="map-status">Loading map…</div>;
+    if (this.state.status === 'error') return <div className="map-status">{this.state.error}</div>;
+
+    const { location } = this.state;
+    const tiles = buildTileGrid(location, {
+      width: globalThis.innerWidth || 768,
+      height: globalThis.innerHeight || 1366,
+    });
     return (
-      <div style={styles.map}></div>
+      <div className="map-page" aria-label={`Map centered on ${location.name}`}>
+        <div className="map-tile-layer" aria-hidden="true">
+          {tiles.map((tile) => (
+            <img className="map-tile" key={tile.key} src={tile.url} alt="" draggable="false"
+              style={{ left: tile.left, top: tile.top }} />
+          ))}
+        </div>
+        <div className="map-shade" aria-hidden="true" />
+        <div className="map-center-marker" aria-hidden="true"><span /></div>
+        <div className="map-location-label">{location.name}</div>
+        <div className="map-attribution">
+          © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>
+          {' '}© <a href="https://carto.com/attributions">CARTO</a>
+        </div>
+      </div>
     );
   }
-
 }

--- a/src/providers/map.js
+++ b/src/providers/map.js
@@ -1,0 +1,44 @@
+export const CARTO_DARK_URL = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}@2x.png';
+const TILE_SIZE = 256;
+const MAX_LATITUDE = 85.05112878;
+const SUBDOMAINS = ['a', 'b', 'c', 'd'];
+
+export const projectToTile = ({ lat, long }, zoom) => {
+  const latitude = Math.max(-MAX_LATITUDE, Math.min(MAX_LATITUDE, lat));
+  const scale = 2 ** zoom;
+  const radians = latitude * Math.PI / 180;
+  return {
+    x: ((long + 180) / 360) * scale,
+    y: ((1 - Math.asinh(Math.tan(radians)) / Math.PI) / 2) * scale,
+  };
+};
+
+export const buildTileGrid = (location, {
+  zoom = 12, width = 768, height = 1366, tileSize = TILE_SIZE, overscan = 1,
+} = {}) => {
+  const center = projectToTile(location, zoom);
+  const scale = 2 ** zoom;
+  const originX = center.x * tileSize - width / 2;
+  const originY = center.y * tileSize - height / 2;
+  const startX = Math.floor(originX / tileSize) - overscan;
+  const endX = Math.floor((originX + width) / tileSize) + overscan;
+  const startY = Math.max(0, Math.floor(originY / tileSize) - overscan);
+  const endY = Math.min(scale - 1, Math.floor((originY + height) / tileSize) + overscan);
+  const tiles = [];
+
+  for (let y = startY; y <= endY; y += 1) {
+    for (let x = startX; x <= endX; x += 1) {
+      const wrappedX = ((x % scale) + scale) % scale;
+      const subdomain = SUBDOMAINS[(wrappedX + y) % SUBDOMAINS.length];
+      tiles.push({
+        key: `${zoom}-${x}-${y}`,
+        left: x * tileSize - originX,
+        top: y * tileSize - originY,
+        url: CARTO_DARK_URL
+          .replace('{s}', subdomain).replace('{z}', zoom)
+          .replace('{x}', wrappedX).replace('{y}', y),
+      });
+    }
+  }
+  return tiles;
+};

--- a/test/map.test.js
+++ b/test/map.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildTileGrid, projectToTile } from '../src/providers/map.js';
+
+test('projects known coordinates into Web Mercator tiles', () => {
+  assert.deepEqual(projectToTile({ lat: 0, long: 0 }, 1), { x: 1, y: 1 });
+  const sanFrancisco = projectToTile({ lat: 37.7749, long: -122.4194 }, 12);
+  assert.ok(sanFrancisco.x > 654 && sanFrancisco.x < 656);
+  assert.ok(sanFrancisco.y > 1582 && sanFrancisco.y < 1584);
+});
+
+test('builds a viewport-covering CARTO dark tile grid', () => {
+  const tiles = buildTileGrid({ lat: 37.7749, long: -122.4194 }, {
+    zoom: 12, width: 768, height: 1366,
+  });
+  assert.ok(tiles.length >= 30);
+  assert.ok(tiles.every(({ url }) => /^https:\/\/[a-d]\.basemaps\.cartocdn\.com\/dark_all\/12\/\d+\/\d+@2x\.png$/.test(url)));
+  assert.ok(Math.min(...tiles.map(({ left }) => left)) < 0);
+  assert.ok(Math.max(...tiles.map(({ left }) => left)) + 256 > 768);
+  assert.ok(Math.min(...tiles.map(({ top }) => top)) < 0);
+  assert.ok(Math.max(...tiles.map(({ top }) => top)) + 256 > 1366);
+});


### PR DESCRIPTION
## Summary
- replace the broken unauthenticated Google Static Maps image
- center a dependency-free CARTO dark tile mosaic on Reflectrum’s configured location
- add a location marker, full-screen states, and OpenStreetMap/CARTO attribution
- test Web Mercator projection and viewport tile coverage

## Verification
- npm run check

## Stack
1. #32
2. **This PR**
3. #33
4. #35